### PR TITLE
Add test case for bin/send

### DIFF
--- a/bin/balance
+++ b/bin/balance
@@ -54,7 +54,7 @@ const BalanceProgram = {
 if (require.main === module) {
   const params = require('../lib/args');
   BalanceProgram.start(params)
-    .then(balance => global.console.log(balance))
+    .then(balance => process.stdout.write(`${balance}\n`))
     .catch(err => console.error(err));
 }
 

--- a/bin/proxy
+++ b/bin/proxy
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * ProxyProgram.start
+ */
+const ProxyProgram = {
+  start: (program) => {
+    const CryptoRPC = require('../lib');
+    const {
+      currency,
+      host,
+      port,
+      user,
+      password,
+      chain,
+      protocol,
+      rpcUser,
+      rpcPass,
+      rpcPort,
+      token,
+      params,
+      method,
+    } = program;
+
+    let rpcs = new CryptoRPC({
+      chain,
+      host,
+      rpcPort: port || rpcPort,
+      rpcUser: user || rpcUser,
+      rpcPass: password || rpcPass,
+      protocol,
+      token,
+    });
+    const proxy = rpcs.get(currency);
+    return proxy.asyncCall(method, [...params.split(/,/)]);
+  }
+};
+
+if (require.main === module) {
+  const params = require('../lib/args');
+  ProxyProgram.start(params)
+    .then(result => process.stdout.write(`${result}\n`))
+    .catch(err => console.error(err));
+}
+
+
+module.exports = ProxyProgram;

--- a/bin/send
+++ b/bin/send
@@ -37,6 +37,7 @@ const SendProgram = {
       rpcPort,
       token,
       amount,
+      unlock,
     } = program;
 
     let rpcs = new CryptoRPC({
@@ -48,7 +49,12 @@ const SendProgram = {
       protocol,
       token,
     });
-    return rpcs.unlockAndSendToAddress({currency, address, amount});
+
+    const sendParams = { currency, address, amount };
+    if (unlock) {
+      return rpcs.unlockAndSendToAddress(sendParams);
+    }
+    return rpcs.sendToAddress(sendParams);
   }
 };
 

--- a/lib/args.js
+++ b/lib/args.js
@@ -14,7 +14,11 @@ program
   .option('--password <password>')
   .option('--protocol <protocol>')
   .option('--amount <amount>')
-  .option('--token <token>');
+  .option('--token <token>')
+  .option('--unlock <bool>')
+  .option('--method <proxy method>')
+  // params should be comma seperated values
+  .option('--params <method parameters>');
 
 function chainFromCurrency(currency) {
   if (ERC20Currencies.includes(currency)) {

--- a/tests/cli
+++ b/tests/cli
@@ -9,7 +9,8 @@
     --host localhost \
     --currency BTC
     )"
-  [ "$result" -eq 0 ]
+    echo $result
+  [ "$result" -eq 5000000000 ]
 }
 
 @test "get BCH balance" {
@@ -21,5 +22,34 @@
     --host localhost \
     --currency BCH
     )"
-  [ "$result" -eq 0 ]
+    echo $result
+  [ "$result" -eq 5000000000 ]
+}
+
+@test "send some BTC" {
+  result="$(
+    bin/send \
+    --user cryptorpc \
+    --password local321 \
+    --port 8333 \
+    --host localhost \
+    --currency BTC \
+    --address 2NGFWyW3LBPr6StDuDSNFzQF3Jouuup1rua \
+    --amount 1000
+    )"
+  [ "${#result}" -eq 64 ]
+}
+
+@test "send some BCH" {
+  result="$(
+    bin/send \
+    --user cryptorpc \
+    --password local321 \
+    --port 8333 \
+    --host localhost \
+    --currency BTC \
+    --address 2NGFWyW3LBPr6StDuDSNFzQF3Jouuup1rua \
+    --amount 1000
+    )"
+  [ "${#result}" -eq 64 ]
 }

--- a/tests/cli
+++ b/tests/cli
@@ -9,7 +9,6 @@
     --host localhost \
     --currency BTC
     )"
-    echo $result
   [ "$result" -eq 5000000000 ]
 }
 
@@ -22,7 +21,6 @@
     --host localhost \
     --currency BCH
     )"
-    echo $result
   [ "$result" -eq 5000000000 ]
 }
 

--- a/tests/cli_runner
+++ b/tests/cli_runner
@@ -3,6 +3,25 @@
 BTC_CONTAINER=$(docker-compose run -p8333:8333 -d bitcoin)
 BCH_CONTAINER=$(docker-compose run -p9333:9333 -d bitcoin-cash)
 sleep 1
+
+bin/proxy \
+  --method generate \
+  --params 101 \
+  --user cryptorpc \
+  --password local321 \
+  --port 8333 \
+  --host localhost \
+  --currency BTC 2>&1 1>/dev/null
+
+bin/proxy \
+  --method generate \
+  --params 101 \
+  --user cryptorpc \
+  --password local321 \
+  --port 9333 \
+  --host localhost \
+  --currency BCH 2>&1 1>/dev/null
+
 npx bats tests/cli
 result=$?
 docker stop ${BTC_CONTAINER} ${BCH_CONTAINER}


### PR DESCRIPTION
This adds a bats test for `bin/send` plus necessary setup.

  * add bin/proxy in order to generate blocks (and any other crypto
        command)
  * update bin/balance tests for nodes with generated blocks
  * add test case for bin/send
  * add --unlock switch to support both encrypted and non-encrypted wallets