### PR TITLE
updating eth return array and updating unlockAndSendToMany tests

### DIFF
--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -133,19 +133,25 @@ class EthRPC {
 
     let someRequestFailed;
     const errorObject = { success: {}, failure: {} };
-    const result = [];
+    const resultObject = { id: null, amount: null, txid: null, address: null };
+    const resultArray = [];
     for (const [i, request] of payToArray.entries()) {
       const { address, amount } = request;
       const emitData = {
         address: request.address,
         amount: request.amount,
-        id: request.id
+        id: request.id,
+        error: null
       };
       this.emitter.emit('attempt', emitData);
       try {
         const txid = await this.sendToAddress({ address, amount, passphrase });
         errorObject.success[i] = txid;
-        result.push(txid);
+        resultObject.id = request.id;
+        resultObject.amount = amount;
+        resultObject.txid = txid;
+        resultObject.address = address;
+        resultArray.push(resultObject);
         emitData.txid = txid;
         this.emitter.emit('success', emitData);
 
@@ -174,7 +180,7 @@ class EthRPC {
     }
 
     this.emitter.emit('done');
-    return result;
+    return resultArray;
   }
 
   estimateFee({ nBlocks }) {

--- a/tests/btc.js
+++ b/tests/btc.js
@@ -113,19 +113,19 @@ describe('BTC Tests', function() {
 
   it('should be able to send many transactions', async () => {
     let payToArray = [];
-    let transaction1 = {
+    const transaction1 = {
       address: 'mm7mGjBBe1sUF8SFXCW779DX8XrmpReBTg',
       amount: 10000
     };
-    let transaction2 = {
+    const transaction2 = {
       address: 'mm7mGjBBe1sUF8SFXCW779DX8XrmpReBTg',
       amount: 20000
     };
-    let transaction3 = {
+    const transaction3 = {
       address: 'mgoVRuvgbgyZL8iQWfS6TLPZzQnpRMHg5H',
       amount: 30000
     };
-    let transaction4 = {
+    const transaction4 = {
       address: 'mv5XmsNbK2deMDhkVq5M28BAD14hvpQ9b2',
       amount: 40000
     };
@@ -133,14 +133,22 @@ describe('BTC Tests', function() {
     payToArray.push(transaction2);
     payToArray.push(transaction3);
     payToArray.push(transaction4);
-    let maxOutputs = 2;
-    let maxValue = 1e8;
-    let eventEmitter = rpcs.rpcs.BTC.emitter;
+    const maxOutputs = 2;
+    const maxValue = 1e8;
+    const eventEmitter = rpcs.rpcs.BTC.emitter;
+    let eventCounter = 0;
     let emitResults = [];
-    eventEmitter.on('success', (emitData) => {
-      emitResults.push(emitData);
+    const emitPromise = new Promise(resolve => {
+      eventEmitter.on('success', (emitData) => {
+        eventCounter++;
+        emitResults.push(emitData);
+        if (eventCounter === 3) {
+          resolve();
+        }
+      });
     });
     const outputArray = await rpcs.unlockAndSendToAddressMany({ payToArray, passphrase: currencyConfig.unlockPassword, time: 1000, maxValue, maxOutputs });
+    await emitPromise;
     expect(outputArray).to.have.lengthOf(4);
     for (let transaction of outputArray) {
       assert(transaction.txid);

--- a/tests/btc.js
+++ b/tests/btc.js
@@ -135,11 +135,26 @@ describe('BTC Tests', function() {
     payToArray.push(transaction4);
     let maxOutputs = 2;
     let maxValue = 1e8;
+    let eventEmitter = rpcs.rpcs.BTC.emitter;
+    let emitResults = [];
+    eventEmitter.on('success', (emitData) => {
+      emitResults.push(emitData);
+    });
     const outputArray = await rpcs.unlockAndSendToAddressMany({ payToArray, passphrase: currencyConfig.unlockPassword, time: 1000, maxValue, maxOutputs });
     expect(outputArray).to.have.lengthOf(4);
     for (let transaction of outputArray) {
       assert(transaction.txid);
       expect(transaction.txid).to.have.lengthOf(64);
+    }
+    for (let emitData of emitResults) {
+      assert(emitData.address);
+      assert(emitData.amount);
+      assert(emitData.txid);
+      assert(emitData.batchData);
+      expect(emitData.error === null);
+      expect(emitData.vout === 0 || emitData.vout === 1);
+      let transactionObj = {address: emitData.address, amount: emitData.amount};
+      expect(payToArray.includes(transactionObj));
     }
   });
 

--- a/tests/erc20.js
+++ b/tests/erc20.js
@@ -58,18 +58,32 @@ describe('ERC20 Tests', function() {
     const address = config.currencyConfig.sendTo;
     const amount = '1000';
     const payToArray = [{ address, amount }, {address, amount}];
-    let eventEmitter = rpcs.rpcs.ETH.emitter;
-    eventEmitter.on('success', (emitData) => {
-      assert(emitData.txid);
-      expect(emitData.error === null);
-      expect(emitData.address === address);
-      expect(emitData.amount === amount);
+    const eventEmitter = rpcs.rpcs.ERC20.emitter;
+    let eventCounter = 0;
+    let emitResults = [];
+    const emitPromise = new Promise(resolve => {
+      eventEmitter.on('success', (emitData) => {
+        eventCounter++;
+        emitResults.push(emitData);
+        if (eventCounter === 2) {
+          resolve(emitResults);
+        }
+      });
     });
     const outputArray = await rpcs.unlockAndSendToAddressMany({
       currency,
       payToArray,
       passphrase: currencyConfig.unlockPassword
     });
+    await emitPromise;
+    assert(emitResults[0].txid);
+    expect(emitResults[0].error === null);
+    expect(emitResults[0].address === address);
+    expect(emitResults[0].amount === amount);
+    assert(emitResults[1].txid);
+    expect(emitResults[1].error === null);
+    expect(emitResults[1].address === address);
+    expect(emitResults[1].amount === amount);
     assert.isTrue(outputArray.length === 2);
     assert.isTrue(util.isHex(outputArray[0].txid));
     assert.isTrue(util.isHex(outputArray[1].txid));

--- a/tests/eth.js
+++ b/tests/eth.js
@@ -143,13 +143,23 @@ describe('ETH Tests', function() {
     const address = config.currencyConfig.sendTo;
     const amount = '1000';
     const payToArray = [{ address, amount }, {address, amount}];
-    const txids = await rpcs.unlockAndSendToAddressMany({
+    let eventEmitter = rpcs.rpcs.ETH.emitter;
+    eventEmitter.on('success', (emitData) => {
+      assert(emitData.txid);
+      expect(emitData.error === null);
+      expect(emitData.address === address);
+      expect(emitData.amount === amount);
+    });
+    const outputArray = await rpcs.unlockAndSendToAddressMany({
       currency,
       payToArray,
       passphrase: currencyConfig.unlockPassword
     });
-    assert.isTrue(util.isHex(txids[0]));
-    assert.isTrue(txids.length === 2);
+    assert.isTrue(outputArray.length === 2);
+    assert.isTrue(util.isHex(outputArray[0].txid));
+    assert.isTrue(util.isHex(outputArray[1].txid));
+    expect(outputArray[0].txid).to.have.lengthOf(66);
+    expect(outputArray[1].txid).to.have.lengthOf(66);
   });
 
   it('should reject when one of many transactions fails', async () => {


### PR DESCRIPTION
the return array for eth unlockAndSendToAddressMany was just an array of txids but it needs to be an array of objects with fields {id, amount, address, txid} to mirror the btc return object.