### PR TITLE
Fix ethereum error handling

### DIFF
--- a/lib/btc/BtcRpc.js
+++ b/lib/btc/BtcRpc.js
@@ -103,49 +103,44 @@ class BtcRpc {
         currentOutputs++;
       }
       let emitData = {
-        batchData: {},
         txid: '',
         vout: '',
         id: '',
         amount: '',
         address: '',
-        error: null
       };
+      let txid;
+      let txDetails;
       try {
-        let txid = await this.sendMany({ batch:paymentsObj });
+        txid = await this.sendMany({ batch:paymentsObj });
         emitData.txid = txid;
-
-        let txDetails = await this.getTransaction({ txid }).catch(() => null);
-        for (let payment of paymentsArr) {
-          if(txDetails && txDetails.vout) {
-            for (let vout of txDetails.vout) {
-              if (vout.scriptPubKey.addresses[0].includes(payment.address)) {
-                emitData.vout = vout.n;
-                payment.vout = vout.n;
-              }
-            }
-          }
-          payment.txid = txid;
-          payToArrayResult.push(payment);
-
-          emitData.batchData = paymentsObj;
-          emitData.id = payment.id;
-          emitData.amount = payment.amount;
-          emitData.address = payment.address;
-          this.emitter.emit('success', emitData);
+      } catch (error) {
+        emitData.error = error;
+      }
+      try {
+        if (txid) {
+          txDetails = await this.getTransaction({ txid });
         }
       } catch (error) {
-        for (let payment of paymentsArr) {
-          payment.error = error;
-          payToArrayResult.push(payment);
-
-          emitData.error = error;
-          emitData.batchData = paymentsObj;
-          emitData.address = payment.address;
-          emitData.id = payment.id;
-          emitData.amount = payment.amount;
-          this.emitter.emit('failure', emitData);
+        console.error(`Unable to get transaction details for txid: ${txid}.`);
+      }
+      for (let payment of paymentsArr) {
+        if (txDetails && txDetails.vout) {
+          for (let vout of txDetails.vout) {
+            if (vout.scriptPubKey.addresses[0].includes(payment.address)) {
+              emitData.vout = vout.n;
+            }
+          }
         }
+        emitData.id = payment.id;
+        emitData.amount = payment.amount;
+        emitData.address = payment.address;
+        if (emitData.error) {
+          this.emitter.emit('failure', emitData);
+        } else {
+          this.emitter.emit('success', emitData);
+        }
+        payToArrayResult.push(emitData);
       }
     }
     await this.walletLock();

--- a/lib/btc/BtcRpc.js
+++ b/lib/btc/BtcRpc.js
@@ -123,6 +123,7 @@ class BtcRpc {
         }
       } catch (error) {
         console.error(`Unable to get transaction details for txid: ${txid}.`);
+        console.error(error);
       }
       for (let payment of paymentsArr) {
         if (txDetails && txDetails.vout) {

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -133,7 +133,6 @@ class EthRPC {
 
     let someRequestFailed;
     const errorObject = { success: {}, failure: {} };
-    const resultObject = { id: null, amount: null, txid: null, address: null };
     const resultArray = [];
     for (const [i, request] of payToArray.entries()) {
       const { address, amount } = request;
@@ -147,12 +146,8 @@ class EthRPC {
       try {
         const txid = await this.sendToAddress({ address, amount, passphrase });
         errorObject.success[i] = txid;
-        resultObject.id = request.id;
-        resultObject.amount = amount;
-        resultObject.txid = txid;
-        resultObject.address = address;
-        resultArray.push(resultObject);
         emitData.txid = txid;
+        resultArray.push(emitData);
         this.emitter.emit('success', emitData);
 
         await new Promise(async (resolve, reject) => {

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -127,12 +127,7 @@ class EthRPC {
     const resultArray = [];
     for (const payment of payToArray) {
       const { address, amount, id } = payment;
-      const emitData = {
-        address: address,
-        amount: amount,
-        id: id,
-        error: null
-      };
+      const emitData = { address, amount, id };
       this.emitter.emit('attempt', emitData);
       try {
         const txid = await this.sendToAddress({ address, amount, passphrase });

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -120,32 +120,22 @@ class EthRPC {
   }
 
   async unlockAndSendToAddressMany({ payToArray, passphrase }) {
-    function RpcException(message) {
-      const e = new Error(message);
-      e.name = 'failedRequest';
-      e.data = errorObject;
-      return e;
-    }
-
     if (passphrase === undefined) {
       passphrase = await passwordPromptAsync('> ');
     }
 
-    let someRequestFailed;
-    const errorObject = { success: {}, failure: {} };
     const resultArray = [];
-    for (const [i, request] of payToArray.entries()) {
-      const { address, amount } = request;
+    for (const payment of payToArray) {
+      const { address, amount, id } = payment;
       const emitData = {
-        address: request.address,
-        amount: request.amount,
-        id: request.id,
+        address: address,
+        amount: amount,
+        id: id,
         error: null
       };
       this.emitter.emit('attempt', emitData);
       try {
         const txid = await this.sendToAddress({ address, amount, passphrase });
-        errorObject.success[i] = txid;
         emitData.txid = txid;
         resultArray.push(emitData);
         this.emitter.emit('success', emitData);
@@ -164,14 +154,10 @@ class EthRPC {
           }
         });
       }  catch (error) {
-        errorObject.failure[i] = error;
-        someRequestFailed = true;
         emitData.error = error;
+        resultArray.push(emitData);
         this.emitter.emit('failure', emitData);
       }
-    }
-    if (someRequestFailed) {
-      throw RpcException('At least one of many requests Failed');
     }
 
     this.emitter.emit('done');

--- a/tests/bch.js
+++ b/tests/bch.js
@@ -154,13 +154,24 @@ describe('BCH Tests', function() {
         amount: 1
       },
     ];
-    let outputArray;
-    try {
-      outputArray = await rpcs.unlockAndSendToAddressMany({ payToArray, passphrase: currencyConfig.unlockPassword, time: 1000 });
-    } catch (error) {
-      assert(error.data);
-    }
-    assert(outputArray[1].error);
+    const eventEmitter = rpcs.rpcs.BCH.emitter;
+    let emitResults = [];
+    const emitPromise = new Promise(resolve => {
+      eventEmitter.on('failure', (emitData) => {
+        emitResults.push(emitData);
+        resolve();
+      });
+    });
+    const outputArray = await rpcs.unlockAndSendToAddressMany({
+      currency,
+      payToArray,
+      passphrase: currencyConfig.unlockPassword
+    });
+    await emitPromise;
+    assert(!outputArray[1].txid);
+    expect(outputArray[1].error).to.equal(emitResults[0].error);
+    expect(emitResults.length).to.equal(1);
+    assert(emitResults[0].error);
   });
 
   it('should be able to get a transaction', async () => {

--- a/tests/bch.js
+++ b/tests/bch.js
@@ -137,7 +137,6 @@ describe('BCH Tests', function() {
       assert(emitData.address);
       assert(emitData.amount);
       assert(emitData.txid);
-      assert(emitData.batchData);
       expect(emitData.error === null);
       expect(emitData.vout === 0 || emitData.vout === 1);
       let transactionObj = {address: emitData.address, amount: emitData.amount};

--- a/tests/btc.js
+++ b/tests/btc.js
@@ -150,6 +150,9 @@ describe('BTC Tests', function() {
     const outputArray = await rpcs.unlockAndSendToAddressMany({ payToArray, passphrase: currencyConfig.unlockPassword, time: 1000, maxValue, maxOutputs });
     await emitPromise;
     expect(outputArray).to.have.lengthOf(4);
+    expect(outputArray[0].txid).to.equal(outputArray[1].txid);
+    expect(outputArray[2].txid).to.equal(outputArray[3].txid);
+    expect(outputArray[1].txid).to.not.equal(outputArray[2].txid);
     for (let transaction of outputArray) {
       assert(transaction.txid);
       expect(transaction.txid).to.have.lengthOf(64);

--- a/tests/btc.js
+++ b/tests/btc.js
@@ -161,7 +161,6 @@ describe('BTC Tests', function() {
       assert(emitData.address);
       assert(emitData.amount);
       assert(emitData.txid);
-      assert(emitData.batchData);
       expect(emitData.error === null);
       expect(emitData.vout === 0 || emitData.vout === 1);
       let transactionObj = {address: emitData.address, amount: emitData.amount};

--- a/tests/btc.js
+++ b/tests/btc.js
@@ -174,15 +174,26 @@ describe('BTC Tests', function() {
     const amount = '1000';
     const payToArray = [
       { address, amount },
-      { address: 'funkyColdMedina', amount: 1 },
+      { address: 'funkyColdMedina', amount: 1 }
     ];
-    let outputArray;
-    try {
-      outputArray = await rpcs.unlockAndSendToAddressMany({ payToArray, passphrase: currencyConfig.unlockPassword, time: 1000 });
-    } catch (error) {
-      assert(error.data);
-    }
-    assert(outputArray[1].error);
+    const eventEmitter = rpcs.rpcs.BTC.emitter;
+    let emitResults = [];
+    const emitPromise = new Promise(resolve => {
+      eventEmitter.on('failure', (emitData) => {
+        emitResults.push(emitData);
+        resolve();
+      });
+    });
+    const outputArray = await rpcs.unlockAndSendToAddressMany({
+      currency,
+      payToArray,
+      passphrase: currencyConfig.unlockPassword
+    });
+    await emitPromise;
+    assert(!outputArray[1].txid);
+    expect(outputArray[1].error).to.equal(emitResults[0].error);
+    expect(emitResults.length).to.equal(1);
+    assert(emitResults[0].error);
   });
 
   it('should be able to get a transaction', async () => {

--- a/tests/erc20.js
+++ b/tests/erc20.js
@@ -96,14 +96,26 @@ describe('ERC20 Tests', function() {
     const amount = '1000';
     const payToArray = [
       { address, amount },
-      { address: 'funkyColdMedina', amount: 1 },
+      { address: 'funkyColdMedina', amount: 1 }
     ];
-    try {
-      await rpcs.unlockAndSendToAddressMany({ currency, payToArray, passphrase: currencyConfig.unlockPassword });
-    } catch (error) {
-      assert(error.message = 'At least one of many requests Failed');
-      assert(error.data.failure[1]);
-    }
+    const eventEmitter = rpcs.rpcs.ERC20.emitter;
+    let emitResults = [];
+    const emitPromise = new Promise(resolve => {
+      eventEmitter.on('failure', (emitData) => {
+        emitResults.push(emitData);
+        resolve();
+      });
+    });
+    const outputArray = await rpcs.unlockAndSendToAddressMany({
+      currency,
+      payToArray,
+      passphrase: currencyConfig.unlockPassword
+    });
+    await emitPromise;
+    assert(!outputArray[1].txid);
+    expect(outputArray[1].error).to.equal(emitResults[0].error);
+    expect(emitResults.length).to.equal(1);
+    assert(emitResults[0].error);
   });
 
   it('should be able to decode a raw transaction', async () => {

--- a/tests/eth.js
+++ b/tests/eth.js
@@ -174,6 +174,7 @@ describe('ETH Tests', function() {
     assert.isTrue(util.isHex(outputArray[1].txid));
     expect(outputArray[0].txid).to.have.lengthOf(66);
     expect(outputArray[1].txid).to.have.lengthOf(66);
+    expect(outputArray[1].txid).to.not.equal(outputArray[0].txid);
   });
 
   it('should reject when one of many transactions fails', async () => {


### PR DESCRIPTION
this will change how error handling is done in the try catch involving sendtoaddress. Now, we do not want to throw but instead record the error and continue