### PR TITLE
get block transactions when estimating gasPrice

### DIFF
--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -177,9 +177,11 @@ class EthRPC {
       }));
     let medianGasPrices = [];
     for (const block of blocks) {
-      const gasPrices = block.transactions.map(tx => parseInt(tx.gasPrice)).sort();
-      const median = gasPrices[[Math.floor(block.transactions.length / 2)]];
-      medianGasPrices.push(median);
+      if (block && block.transactions.length) {
+        const gasPrices = block.transactions.map(tx => parseInt(tx.gasPrice)).sort();
+        const median = gasPrices[[Math.floor(block.transactions.length / 2)]];
+        medianGasPrices.push(median);
+      }
     }
     const shortAverage = Math.ceil(medianGasPrices.slice(0, medianGasPrices.length/2).reduce((acc, cur) => acc + cur, 0) / (medianGasPrices.length / 2));
     const longAverage = Math.ceil(medianGasPrices.reduce((acc, cur) => acc + cur, 0) / medianGasPrices.length);

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -181,8 +181,8 @@ class EthRPC {
       const median = gasPrices[[Math.floor(block.transactions.length / 2)]];
       medianGasPrices.push(median);
     }
-    const shortAverage = medianGasPrices.slice(0, medianGasPrices.length/2).reduce((acc, cur) => acc + cur, 0) / (medianGasPrices.length / 2);
-    const longAverage = medianGasPrices.reduce((acc, cur) => acc + cur, 0) / medianGasPrices.length;
+    const shortAverage = Math.ceil(medianGasPrices.slice(0, medianGasPrices.length/2).reduce((acc, cur) => acc + cur, 0) / (medianGasPrices.length / 2));
+    const longAverage = Math.ceil(medianGasPrices.reduce((acc, cur) => acc + cur, 0) / medianGasPrices.length);
     const divergence = shortAverage - longAverage;
     const estimate = (divergence < 0)? shortAverage: shortAverage + divergence;
     const rpcEstimate = await this.web3.eth.getGasPrice();

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -179,7 +179,7 @@ class EthRPC {
     for (const block of blocks) {
       if (block && block.transactions.length) {
         const gasPrices = block.transactions.map(tx => parseInt(tx.gasPrice)).sort();
-        const median = gasPrices[[Math.floor(block.transactions.length / 2)]];
+        const median = gasPrices[Math.floor(block.transactions.length / 2)];
         medianGasPrices.push(median);
       }
     }

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -170,8 +170,23 @@ class EthRPC {
   }
 
   async estimateGasPrice() {
-    const gasEstimate = await this.web3.eth.getGasPrice();
-    return parseInt(gasEstimate);
+    const bestBlock = await this.web3.eth.getBlockNumber();
+    const blocks = await Promise.all([...Array(10).keys()]
+      .map((n) => {
+        return this.web3.eth.getBlock(bestBlock - n, 1);
+      }));
+    let medianGasPrices = [];
+    for (const block of blocks) {
+      const gasPrices = block.transactions.map(tx => parseInt(tx.gasPrice)).sort();
+      const median = gasPrices[[Math.floor(block.transactions.length / 2)]];
+      medianGasPrices.push(median);
+    }
+    const shortAverage = medianGasPrices.slice(0, medianGasPrices.length/2).reduce((acc, cur) => acc + cur, 0) / (medianGasPrices.length / 2);
+    const longAverage = medianGasPrices.reduce((acc, cur) => acc + cur, 0) / medianGasPrices.length;
+    const divergence = shortAverage - longAverage;
+    const estimate = (divergence < 0)? shortAverage: shortAverage + divergence;
+    const rpcEstimate = await this.web3.eth.getGasPrice();
+    return Math.max(estimate, parseInt(rpcEstimate));
   }
 
   async getBestBlockHash() {

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -169,33 +169,9 @@ class EthRPC {
     return this.estimateGasPrice(nBlocks);
   }
 
-  async estimateGasPrice({ nBlocks = 4 } = {}) {
-    const bestBlock = await this.web3.eth.getBlockNumber();
-    const gasPrices = [];
-    for (let i = 0; i < nBlocks; i++) {
-      const block = await this.web3.eth.getBlock(bestBlock - i);
-      const txs = await Promise.all(
-        block.transactions.map((txid) => {
-          return this.web3.eth.getTransaction(txid);
-        }));
-      var blockGasPrices = txs.map((tx) => {
-        return tx.gasPrice;
-      });
-      // sort gas prices in descending order
-      blockGasPrices = blockGasPrices.sort((a, b) => {
-        return b - a;
-      });
-      var txCount = txs.length;
-      var lowGasPriceIndex = txCount > 1 ? txCount - 2 : 0;
-      if (txCount > 0) {
-        gasPrices.push(blockGasPrices[lowGasPriceIndex]);
-      }
-    }
-    var gethGasPrice = await this.web3.eth.getGasPrice();
-    var estimate = gasPrices.reduce((a, b) => {
-      return Math.max(a, b);
-    }, gethGasPrice);
-    return estimate;
+  async estimateGasPrice() {
+    const gasEstimate = await this.web3.eth.getGasPrice();
+    return parseInt(gasEstimate);
   }
 
   async getBestBlockHash() {

--- a/tests/eth.js
+++ b/tests/eth.js
@@ -89,7 +89,7 @@ describe('ETH Tests', function() {
   it('should estimate gas price', async () => {
     const gasPrice = await ethRPC.estimateGasPrice();
     assert.isDefined(gasPrice);
-    expect(gasPrice).to.be.eq(2 * 10e9);
+    expect(gasPrice).to.be.eq(20300000000);
   });
 
   it('should be able to get a block hash', async () => {

--- a/tests/eth.js
+++ b/tests/eth.js
@@ -89,7 +89,7 @@ describe('ETH Tests', function() {
   it('should estimate gas price', async () => {
     const gasPrice = await ethRPC.estimateGasPrice();
     assert.isDefined(gasPrice);
-    expect(gasPrice).to.be.eq(2.1 * 10e9);
+    expect(gasPrice).to.be.eq(2 * 10e9);
   });
 
   it('should be able to get a block hash', async () => {


### PR DESCRIPTION
Exploding the blocks and doing analysis on gas prices using rpc is not scalable(100's of getTransaction per block of analysis on mainnet). Analysis like that needs to happen against datastore, not over http requests per tx.