### PR TITLE
Allow no port to be specified

### DIFF
--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -17,7 +17,7 @@ class EthRPC {
 
   getWeb3(web3Config) {
     const { protocol, host, port } = web3Config;
-    const connectionString = `${protocol}://${host}:${port}`;
+    const connectionString =  port ? `${protocol}://${host}:${port}` : `${protocol}://${host}`;
     let Provider = null;
     switch (protocol) {
       case 'http':


### PR DESCRIPTION
Right now you can't point crypto-rpc at infura, because port is required