### PR TITLE
updating return from estimateGasPrice

### DIFF
--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -188,7 +188,7 @@ class EthRPC {
     const divergence = shortAverage - longAverage;
     const estimate = (divergence < 0)? shortAverage: shortAverage + divergence;
     const rpcEstimate = await this.web3.eth.getGasPrice();
-    return Math.max(estimate, parseInt(rpcEstimate));
+    return Math.max((isNaN(estimate) ? 0 : estimate), parseInt(rpcEstimate));
   }
 
   async getBestBlockHash() {


### PR DESCRIPTION
Math.max(NaN, 10000000000000) returns a NaN and this is messing up estimate fee