### PR TITLE
Adds optional timeout to config and defaults Xrp Rpc timeout to 30000 ms

### DIFF
--- a/lib/xrp/XrpRpc.js
+++ b/lib/xrp/XrpRpc.js
@@ -14,11 +14,13 @@ class XrpRpc {
       rpcPort,
       host,
       protocol,
-      address
+      address,
+      timeout
     } = config;
     const connectionString = `${protocol}://${host}:${rpcPort}`;
     this.rpc = new RippleAPI({
-      server: connectionString
+      server: connectionString,
+      timeout: timeout || 30000
     });
     this.address = address;
     this.emitter = new EventEmitter();


### PR DESCRIPTION
Using Xrp Rpc on testnet I received timeout failures on some request calls. ripple-lib defaults to 2 seconds for timeout. This allows configuration to override the rpc timeout and if no config passed defaults timeout to 30 seconds.