### PR TITLE
Xrp Rpc Improvements

### DIFF
--- a/lib/xrp/XrpRpc.js
+++ b/lib/xrp/XrpRpc.js
@@ -142,11 +142,16 @@ class XrpRpc {
   }
 
   async sendRawTransaction({ rawTx, alreadyConnected }) {
-    let response = await this.asyncCall('submit', [rawTx], alreadyConnected);
-    if (response.resultCode !== 'tesSUCCESS') {
-      throw new Error('Failed to submit transaction.');
+    try {
+      let response = await this.asyncCall('submit', [rawTx], alreadyConnected);
+      if (response.resultCode !== 'tesSUCCESS') {
+        throw new Error('Failed to submit transaction.');
+      }
+      return response.tx_json.hash;
+    } catch (err) {
+      this.emitter.emit('error', { error: err });
+      throw err;
     }
-    return response.tx_json.hash;
   }
 
   async decodeRawTransaction({ rawTx }) {
@@ -164,7 +169,7 @@ class XrpRpc {
 
   async getBalance({ address }) {
     let balance =  await this.asyncCall('getBalances', [this.address || address]);
-    let balanceAmount = balance.find((b) => (b.currency === this.config.currency));
+    let balanceAmount = balance.find((b) => (b.currency === 'XRP'));
     let val = balanceAmount? balanceAmount.value: 0;
     return parseFloat(val);
   }


### PR DESCRIPTION
- don't use `config.currency` to check balance, since ChainInterface does not supply `currency`
- emit any error from `sendRawTransaction` in addition to throwing