### PR TITLE
Poll for tesSUCCESS result code on terQUEUED when sending raw tx

### DIFF
--- a/lib/xrp/XrpRpc.js
+++ b/lib/xrp/XrpRpc.js
@@ -6,6 +6,7 @@ const EventEmitter = require('events');
 const rippleHashes = require('ripple-hashes');
 
 const passwordPromptAsync = util.promisify(promptly.password);
+const setTimeoutAsync = util.promisify(setTimeout);
 
 class XrpRpc {
   constructor(config) {
@@ -160,13 +161,38 @@ class XrpRpc {
     return tx;
   }
 
-  async sendRawTransaction({ rawTx }) {
+  async sendRawTransaction({ rawTx, pollCountMax = 4, pollIntervalMs = 3000 }) {
+    const pollForTransactionSuccess = async (txid, max, interval) => {
+      for (let i = 0; i < max; i++) {
+        await setTimeoutAsync(interval);
+        try {
+          const tx = await this.getTransaction({ txid });
+          if (tx.meta && tx.meta.TransactionResult === 'tesSUCCESS') {
+            return;
+          }
+        } catch (e) {
+          continue;
+        }
+      }
+      throw new Error('Transaction result code is not tesSUCCESS after multiple polls');
+    };
+
     try {
       let response = await this.asyncCall('submit', [rawTx]);
       if (response.resultCode !== 'tesSUCCESS') {
         const err = new Error('Failed to submit transaction: ' + response.resultMessage);
         err.conclusive = true; // used by server
-        throw err;
+        // Tx fee lower than current required network fee, tx will be included in next block where fee is sufficient if possible
+        // Attempt to poll transaction status for tesSUCCESS result code for ~3 blocks or return original terQUEUED error
+        if (response.resultCode === 'terQUEUED') {
+          try {
+            await pollForTransactionSuccess(response.tx_json.hash, pollCountMax, pollIntervalMs );
+          } catch (_) {
+            throw err;
+          }
+        } else {
+          throw err;
+        }
       }
       return response.tx_json.hash;
     } catch (err) {


### PR DESCRIPTION
This adds polling to XRP rpc `sendRawTransaction` fn. If submitting the transaction results in a `terQUEUED` result code, we poll 4 times at 3 second intervals to see if the transaction has succeeded. 

If it does succeed within the polling time, then we return success as normal, otherwise we return original `terQUEUED` error, as this transaction may still succeed in the future.