### PR TITLE
Adds improvements to connection handling for ripple-lib

### DIFF
--- a/lib/xrp/XrpRpc.js
+++ b/lib/xrp/XrpRpc.js
@@ -24,7 +24,6 @@ class XrpRpc {
     });
     this.address = address;
     this.emitter = new EventEmitter();
-    this.connectionHandled = false;
     this.connectionIdleTimeout = null;
     this.connectionIdleMs = config.connectionIdleMs || 120000;
     this.rpc.on('error', () => {}); // ignore rpc connection errors as we reconnect if nec each request

--- a/lib/xrp/XrpRpc.js
+++ b/lib/xrp/XrpRpc.js
@@ -27,27 +27,25 @@ class XrpRpc {
     this.connectionHandled = false;
     this.connectionIdleTimeout = null;
     this.connectionIdleMs = config.connectionIdleMs || 120000;
+    this.rpc.on('error', () => {}); // ignore rpc connection errors as we reconnect if necc each request
   }
 
   async asyncCall(method, args) {
     // clear idle timer if exists
     clearTimeout(this.connectionIdleTimeout);
     // reset idle timer
-    this.connectionIdleTimeout = setTimeout(() => {
-      this.rpc.disconnect().then(() => {
-        this.connectionHandled = false;
-      }).catch(() => {
-        // swallow error and attempt to reconnect on next call
-        this.connectionHandled = false;
-      });
+    this.connectionIdleTimeout = setTimeout(async () => {
+      try {
+        await this.rpc.disconnect();
+      } catch (_) {
+        // ignore disconnection error on idle
+      }
     }, this.connectionIdleMs);
     this.connectionIdleTimeout.unref();
 
-    if (!this.connectionHandled) {
+    if (!this.rpc.isConnected()) {
       // if there is an error connecting, throw error and try again on next call
       await this.rpc.connect();
-      // connection now handled by rpc
-      this.connectionHandled = true;
     }
 
     let result;

--- a/lib/xrp/XrpRpc.js
+++ b/lib/xrp/XrpRpc.js
@@ -27,7 +27,7 @@ class XrpRpc {
     this.connectionHandled = false;
     this.connectionIdleTimeout = null;
     this.connectionIdleMs = config.connectionIdleMs || 120000;
-    this.rpc.on('error', () => {}); // ignore rpc connection errors as we reconnect if necc each request
+    this.rpc.on('error', () => {}); // ignore rpc connection errors as we reconnect if nec each request
   }
 
   async asyncCall(method, args) {

--- a/tests/xrp.js
+++ b/tests/xrp.js
@@ -218,8 +218,12 @@ describe('XRP Tests', function() {
 
   it('should disconnect from rpc when idle', async () => {
     await rpcs.getTip({ currency });
-    assert(xrpRPC.connectionHandled === true, 'connection should be handled');
+    assert(xrpRPC.rpc.isConnected() === true, 'connection should be connection');
     await new Promise((resolve) => setTimeout(resolve, 300));
-    assert(xrpRPC.connectionHandled === false, 'connection should not be handled anymore');
+    assert(xrpRPC.rpc.isConnected() === false, 'connection should be disconnected');
+  });
+
+  it('should handle emitted connection errors from rpc with noop', async () => {
+    xrpRPC.rpc.emit('error', new Error('connection error xrp'));
   });
 });

--- a/tests/xrp.js
+++ b/tests/xrp.js
@@ -218,7 +218,7 @@ describe('XRP Tests', function() {
 
   it('should disconnect from rpc when idle', async () => {
     await rpcs.getTip({ currency });
-    assert(xrpRPC.rpc.isConnected() === true, 'connection should be connection');
+    assert(xrpRPC.rpc.isConnected() === true, 'connection should be connected');
     await new Promise((resolve) => setTimeout(resolve, 300));
     assert(xrpRPC.rpc.isConnected() === false, 'connection should be disconnected');
   });


### PR DESCRIPTION
While testing ripple-lib 1.6.1 it was noticed that the connection may not be handled after some number of failed retry attempts. Because of this `this.connectionHandled` can be left true even though the rpc is not connected, resulting in the connection never attempting to reconnect.

Also, ripple-lib 1.6.1 can emit an error that must be handled. We reconnect if necessary each request, so there should be no need to actually do anything with the error, hence the noop.