### PR TITLE
Xrp queued polling

### DIFF
--- a/lib/xrp/XrpRpc.js
+++ b/lib/xrp/XrpRpc.js
@@ -165,7 +165,7 @@ class XrpRpc {
         let counter = 0;
         let ledgerHandler;
         let ledgerHandlerGenerator = (resolve, reject) => {
-          return async (ledger) => {
+          return async () => {
             counter++;
             const tx = await this.getTransaction({ txid: response.tx_json.hash });
             if (tx.validated === true && tx.meta && tx.meta.TransactionResult === 'tesSUCCESS') {
@@ -175,6 +175,7 @@ class XrpRpc {
             if (counter >= 3) {
               // After 3 tries, will reject, causing an error to propagate up to top level
               // in the meantime, emit a 'pending' error
+              this.rpc.removeListener('ledger', ledgerHandler);
               const err = new Error('Transaction is pending and may confirm in the future');
               err.code = 'terQUEUED';
               err.conclusive = true; // used by server
@@ -182,7 +183,7 @@ class XrpRpc {
             }
             return;
           };
-        }
+        };
         await new Promise((resolve, reject) => {
           ledgerHandler = ledgerHandlerGenerator(resolve, reject);
           this.rpc.on('ledger', ledgerHandler);

--- a/lib/xrp/XrpRpc.js
+++ b/lib/xrp/XrpRpc.js
@@ -160,7 +160,7 @@ class XrpRpc {
   async sendRawTransaction({ rawTx }) {
     try {
       let response = await this.asyncCall('submit', [rawTx]);
-      if (true) {//response.resultCode === 'terQUEUED') {
+      if (response.resultCode === 'terQUEUED') {
         // TX was queued; watch chain for 3 blocks to ensure it confirms. If not, throw.
         let counter = 0;
         let ledgerHandler;
@@ -169,8 +169,8 @@ class XrpRpc {
             counter++;
             const tx = await this.getTransaction({ txid: response.tx_json.hash });
             if (tx.validated === true && tx.meta && tx.meta.TransactionResult === 'tesSUCCESS') {
-              //this.rpc.removeListener('ledger', ledgerHandler);
-              //return resolve();
+              this.rpc.removeListener('ledger', ledgerHandler);
+              return resolve();
             }
             if (counter >= 3) {
               // After 3 tries, will reject, causing an error to propagate up to top level

--- a/lib/xrp/XrpRpc.js
+++ b/lib/xrp/XrpRpc.js
@@ -160,14 +160,43 @@ class XrpRpc {
   async sendRawTransaction({ rawTx }) {
     try {
       let response = await this.asyncCall('submit', [rawTx]);
-      if (response.resultCode !== 'tesSUCCESS') {
-        const err = new Error('Failed to submit transaction: ' + response.resultMessage);
-        err.conclusive = true; // used by server
-        throw err;
+      if (true) {//response.resultCode === 'terQUEUED') {
+        // TX was queued; watch chain for 3 blocks to ensure it confirms. If not, throw.
+        let counter = 0;
+        let ledgerHandler;
+        let ledgerHandlerGenerator = (resolve, reject) => {
+          return async (ledger) => {
+            counter++;
+            const tx = await this.getTransaction({ txid: response.tx_json.hash });
+            if (tx.validated === true && tx.meta && tx.meta.TransactionResult === 'tesSUCCESS') {
+              //this.rpc.removeListener('ledger', ledgerHandler);
+              //return resolve();
+            }
+            if (counter >= 3) {
+              // After 3 tries, will reject, causing an error to propagate up to top level
+              // in the meantime, emit a 'pending' error
+              const err = new Error('Transaction is pending and may confirm in the future');
+              err.code = 'terQUEUED';
+              err.conclusive = true; // used by server
+              return reject(err);
+            }
+            return;
+          };
+        }
+        await new Promise((resolve, reject) => {
+          ledgerHandler = ledgerHandlerGenerator(resolve, reject);
+          this.rpc.on('ledger', ledgerHandler);
+        });
+        return response.tx_json.hash;
       }
-      return response.tx_json.hash;
+      if (response.resultCode === 'tesSUCCESS') {
+        return response.tx_json.hash;
+      }
+      // Not queued, nor success, throw an error
+      const err = new Error('Failed to submit transaction: ' + response.resultMessage);
+      err.conclusive = true; // used by server
+      throw err;
     } catch (err) {
-      this.emitter.emit('error', { error: err });
       throw err;
     }
   }


### PR DESCRIPTION
Change XrpRpc sendRawTransaction method, so if it receives the 'terQUEUED' error code from rippled on broadcast, it waits for ledgers to come in. If the tx becomes confirmed within the next 3 ledgers, it returns. If not, it throws an error.