### PR TITLE
Handles tefPAST_SEQ code by checking txid for tesSUCCESS before throwing

### DIFF
--- a/lib/xrp/XrpRpc.js
+++ b/lib/xrp/XrpRpc.js
@@ -168,7 +168,7 @@ class XrpRpc {
           return async () => {
             counter++;
             const tx = await this.getTransaction({ txid: response.tx_json.hash });
-            if (tx.validated === true && tx.meta && tx.meta.TransactionResult === 'tesSUCCESS') {
+            if (tx.meta && tx.meta.TransactionResult === 'tesSUCCESS') {
               this.rpc.removeListener('ledger', ledgerHandler);
               return resolve();
             }
@@ -189,6 +189,13 @@ class XrpRpc {
           this.rpc.on('ledger', ledgerHandler);
         });
         return response.tx_json.hash;
+      }
+      if (response.resultCode === 'tefPAST_SEQ') {
+        // verify that the transaction has been successfully included in or queued for a ledger
+        const tx = await this.getTransaction({ txid: response.tx_json.hash });
+        if (tx.meta && tx.meta.TransactionResult === 'tesSUCCESS') {
+          return response.tx_json.hash;
+        }
       }
       if (response.resultCode === 'tesSUCCESS') {
         return response.tx_json.hash;

--- a/lib/xrp/XrpRpc.js
+++ b/lib/xrp/XrpRpc.js
@@ -190,18 +190,12 @@ class XrpRpc {
         });
         return response.tx_json.hash;
       }
-      if (response.resultCode === 'tefPAST_SEQ') {
-        // verify that the transaction has been successfully included in or queued for a ledger
-        const tx = await this.getTransaction({ txid: response.tx_json.hash });
-        if (tx.meta && tx.meta.TransactionResult === 'tesSUCCESS') {
-          return response.tx_json.hash;
-        }
-      }
       if (response.resultCode === 'tesSUCCESS') {
         return response.tx_json.hash;
       }
       // Not queued, nor success, throw an error
       const err = new Error('Failed to submit transaction: ' + response.resultMessage);
+      err.code = response.resultCode;
       err.conclusive = true; // used by server
       throw err;
     } catch (err) {


### PR DESCRIPTION
This handles `tefPAST_SEQ` code by checking the txid for `tesSUCCESS` before throwing an error. Also removes unnecessary `tx.validated` check for `terQUEUED` code as previously discussed.