### PR TITLE
count undefined confirmations as zero confirmations

### DIFF
--- a/lib/btc/BtcRpc.js
+++ b/lib/btc/BtcRpc.js
@@ -201,7 +201,7 @@ class BtcRpc {
           confirmations: prevTx.confirmations
         });
       }
-      tx.unconfirmedInputs = tx.vin.some(input => input.confirmations < 1);
+      tx.unconfirmedInputs = tx.vin.some(input => !input.confirmations || input.confirmations < 1);
       let totalInputValue = tx.vin.reduce(
         (total, input) => total + input.value * 1e8,
         0


### PR DESCRIPTION
In the case of zero confirmations on an input the confirmations field will be undefined.  Consider undefined confirmations to be the same as zero.