### PR TITLE
enable Web3 providers' second parameter (options)

### DIFF
--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -16,7 +16,7 @@ class EthRPC {
   }
 
   getWeb3(web3Config) {
-    const { protocol, host, port } = web3Config;
+    const { protocol, host, port, options } = web3Config;
     const connectionString =  port ? `${protocol}://${host}:${port}` : `${protocol}://${host}`;
     let Provider = null;
     switch (protocol) {
@@ -39,6 +39,7 @@ class EthRPC {
     if (!Provider) {
       throw new Error('Please provide a valid protocol');
     }
+    if (protocol !== 'ipc') return new Web3(new Provider(connectionString, options || {}));
     return new Web3(new Provider(connectionString));
   }
 


### PR DESCRIPTION
This pull request enables http,https,ws,wss providers to use its constructor's second parameter, "options".

This feature is necessary for Ethereum network because It contains some big blocks which exceeds default websocket payload setting.

A few months ago, I merged exactly same pull request at bitcore repository(https://github.com/bitpay/bitcore/commit/801dbeec3fde07823e278a52fe8b7a4383c35d6c), however it was overwritten by next commit which apply crypto-rpc(https://github.com/bitpay/bitcore/commit/6722c6fb04cb380560ddf2041956565a30ff4a69).