### PR TITLE
xrp tefALREADY is now seen as successful broadcast, do not wait for blocks

### DIFF
--- a/lib/xrp/XrpRpc.js
+++ b/lib/xrp/XrpRpc.js
@@ -160,7 +160,7 @@ class XrpRpc {
   async sendRawTransaction({ rawTx }) {
     try {
       let response = await this.asyncCall('submit', [rawTx]);
-      if (response.resultCode === 'terQUEUED' || response.resultCode === 'tefALREADY') {
+      if (response.resultCode === 'terQUEUED') {
         // TX was queued; watch chain for 3 blocks to ensure it confirms. If not, throw.
         let counter = 0;
         let ledgerHandler;
@@ -172,7 +172,7 @@ class XrpRpc {
               this.rpc.removeListener('ledger', ledgerHandler);
               return resolve();
             }
-            if (counter >= 3) {
+            if (counter >= 10) {
               // After 3 tries, will reject, causing an error to propagate up to top level
               // in the meantime, emit a 'pending' error
               this.rpc.removeListener('ledger', ledgerHandler);
@@ -190,7 +190,7 @@ class XrpRpc {
         });
         return response.tx_json.hash;
       }
-      if (response.resultCode === 'tesSUCCESS') {
+      if (response.resultCode === 'tesSUCCESS' || response.resultCode === 'tefALREADY') {
         return response.tx_json.hash;
       }
       // Not queued, nor success, throw an error


### PR DESCRIPTION
- xrp `tefALREADY` code is now seen as successful broadcast, do not wait for blocks
- xrp `terQUEUED` code will wait for 10 blocks before returning result