### PR TITLE
Move getBlockHash to BtcRpc and derived chains

### DIFF
--- a/lib/btc/BtcRpc.js
+++ b/lib/btc/BtcRpc.js
@@ -257,6 +257,10 @@ class BtcRpc {
     return this.asyncCall('getBlock', [hash]);
   }
 
+  async getBlockHash({ height }) {
+    return this.asyncCall('getBlockHash', [height]);
+  }
+
   async getConfirmations({ txid }) {
     const tx = await this.getTransaction({ txid });
     if (!tx) {

--- a/lib/doge/DogeRpc.js
+++ b/lib/doge/DogeRpc.js
@@ -16,9 +16,5 @@ class DogeRpc extends BtcRpc {
   async getBlock({ hash, verbose = true }) {
     return this.asyncCall('getBlock', [hash, verbose]);
   }
-
-  async getBlockHash({ height }) {
-    return this.asyncCall('getBlockHash', [height]);
-  }
 }
 module.exports = DogeRpc;


### PR DESCRIPTION
`getBlockHash` method has the same signature for DOGE, LTC, and BTC. This moves it from DogeRpc to BtcRpc.