### PR TITLE
Allow verbosity to be specified for getBlock

### DIFF
--- a/lib/btc/BtcRpc.js
+++ b/lib/btc/BtcRpc.js
@@ -253,8 +253,8 @@ class BtcRpc {
     return this.asyncCall('decodeRawTransaction', [rawTx]);
   }
 
-  async getBlock({ hash }) {
-    return this.asyncCall('getBlock', [hash]);
+  async getBlock({ hash, verbose = 1 }) {
+    return this.asyncCall('getBlock', [hash, verbose]);
   }
 
   async getBlockHash({ height }) {


### PR DESCRIPTION
Needed since the default verbosity only includes tx hashes, which would each take another RPC call to get data from