### PR TITLE
Support EVM Type 2 Transaction Fee Estimates

### DIFF
--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -13,6 +13,7 @@ class EthRPC {
     this.web3 = this.getWeb3(this.config);
     this.account = this.config.account;
     this.emitter = new EventEmitter();
+    this.blockCache = new Map();
     this.blockGasPriceCache = new Map();
     this.blockMaxPriorityFeeCache = new Map();
   }
@@ -184,7 +185,7 @@ class EthRPC {
    * @param {number} params.nBlocks - The number of blocks to consider for the estimation.
    * @param {string} [params.txType='0'] - The type of transaction fee estimation. '2' or 'eip-1559' style, '0' or 'legacy'.
    * @param {number} [params.percentile] - Optional: For type 2 txs, The priority fee percentile from last block to use for the estimation.
-   * @param {number} [params.priority] - Optional: For type 2 txs, The priority fFee to be used with the baseFee.
+   * @param {number} [params.priority] - Optional: For type 2 txs, The priority fee to be used with the baseFee.
    * @returns {Promise<number>} The estimated fee. If txType is '2', returns the sum of maxFee and priorityFee. Otherwise, returns a number.
    */
   async estimateFee({ nBlocks, txType = '0', priority, percentile }) {
@@ -192,7 +193,8 @@ class EthRPC {
     switch (_txType) {
       case 'eip-1559':
       case '2':
-        return await this.estimateMaxFee({ percentile, priority }); // default to 2* base + prioity (2.5 gwei) if priority level is set we determine the percentile vale 
+        // defaults to 2 * base fee + prioity fee (2.5 gwei) uses priority fee value or percentile if set
+        return await this.estimateMaxFee({ percentile, priority });
       case 'legacy':
       case '0':
       default:
@@ -210,7 +212,7 @@ class EthRPC {
    * @returns {Promise<number>} The estimated fee.
    */
   async _estimateFee({ cache, rpcEstimate, percentile = 25, getFees }) {
-    const blocks = await this._getRecentBlocks({ cache });
+    const blocks = await this._getRecentBlocks({});
     const percentileFees = this._getPercentileFees({ percentile, blocks, cache, getFees });
     if (!percentileFees.length) {
       return rpcEstimate;
@@ -242,18 +244,19 @@ class EthRPC {
   async estimateMaxFee({ percentile,  priority }) {
     const lastBlock = await this.web3.eth.getBlock('latest');    
     const baseFeePerGas = parseInt(lastBlock.baseFeePerGas) ? parseInt(lastBlock.baseFeePerGas) : 0;
+    const gwei = parseInt(this.web3.utils.toWei('1', 'gwei'));
 
     if (priority && parseInt(priority) > 0) {
       // user defined priority fee
-      return baseFeePerGas + priority;
+      return 2 * baseFeePerGas + (priority * gwei);
     }
     if (percentile && parseInt(percentile) > 0 && parseInt(percentile) <= 100) {
-      // percentile bases priority fee
-      const maxPriorityFee = await this.estimateMaxPriorityFee({percentile});
-      return baseFeePerGas + maxPriorityFee;
+      // percentile priority fee
+      const maxPriorityFee = await this.estimateMaxPriorityFee({ percentile });
+      return 2 * baseFeePerGas + maxPriorityFee;
     }
     // default max fee formmula. ensures inclusion in next block
-    return 2 * baseFeePerGas + parseInt(this.web3.utils.toWei('2.5', 'gwei'));
+    return 2 * baseFeePerGas + (2.5 * gwei); 
   }
 
   /**
@@ -278,21 +281,31 @@ class EthRPC {
   /**
    * Fetches the last n blocks from the blockchain.
    * @param {Object} params - The parameters for fetching the blocks.
-   * @param {Map} params.cache - The cache to use for storing the blocks.
    * @param {number} [params.n=10] - The number of blocks to fetch.
    * @returns {Promise<Array>} The fetched blocks.
    */
-  async _getRecentBlocks({ cache, n = 10 }) {
+  async _getRecentBlocks({ n = 10 }) {
     const bestBlock = await this.web3.eth.getBlockNumber();
-    const blocks = await Promise.all(
-      [...Array(n).keys()].map((n) => {
+    let cache = this.blockCache;
+    let blocks = await Promise.all(
+      [...Array(n).keys()].map(async (n) => {
         const targetBlockNumber = bestBlock - n;
         if (cache && cache.has(targetBlockNumber)) {
           return cache.get(targetBlockNumber);
         }
-        return this.web3.eth.getBlock(targetBlockNumber, 1);
+        const block = await this.web3.eth.getBlock(targetBlockNumber, 1);
+        if(!block) {
+          throw new Error(`Unable to fetch block ${targetBlockNumber}`);
+        }
+        if (cache) {
+          cache.set(targetBlockNumber, block);
+        }
+        return block;
       })
-    );
+    ).catch((err) => { 
+      this.emitter.emit('failure', err);
+      return [];
+    });
     return blocks;
   }
 
@@ -309,21 +322,24 @@ class EthRPC {
     const percentileKey = `percentile${percentile}`;
     let fees = [];
     for (const block of blocks) {
-      if (!block || (!block[percentileKey] && (!block.transactions || !block.transactions.length))) {
+      if (!block || !block.number || (!block.transactions || !block.transactions.length)) {
         continue;
       }
 
       let percentileValue;
       // get percentile fee
-      if (block[percentileKey]) {
-        percentileValue = block[percentileKey];
+      if (cache && cache.has(block.number) && cache.get(block.number)[percentileKey]) {
+        percentileValue = cache.get(block.number)[percentileKey];
       } else {
         const _fees = getFees ? getFees(block.transactions) : block.transactions.map((tx) => parseInt(tx.gasPrice));
         const feesSorted = _fees.sort((a, b) => b - a);
         percentileValue = feesSorted[Math.floor(feesSorted.length * (percentile / 100))];
       }
+      if(!Number.isInteger(percentileValue)) { 
+        continue;
+      }
       // set quick fee retrieval cache
-      if (cache && block.number) {
+      if (cache) {
         let blockFees = cache.has(block.number) ? cache.get(block.number) : {};
         blockFees[percentileKey] = percentileValue;
         cache.set(block.number, blockFees);
@@ -331,9 +347,7 @@ class EthRPC {
           cache.delete(Array.from(cache.keys()).sort()[0]);
         }
       }
-      if(Number.isInteger(percentileValue)) {
-        fees.push(percentileValue);
-      }
+      fees.push(percentileValue);
     }
     return fees;
   }

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -198,25 +198,26 @@ class EthRPC {
 
   async estimateGasPrice() {
     const rpcEstimate = parseInt(await this.web3.eth.getGasPrice());
-    return _estimateFee(this.blockGasPriceCache, rpcEstimate);
+    return this._estimateFee(this.blockGasPriceCache, rpcEstimate);
   }
 
-  async estimateBaseFee({ nBlocks }) {
-    const latestBlock = await web3.eth.getBlock('latest');
-    const rpcEstimate = latestBlock.baseFeePerGas ?
-      parseInt(latestBlock.baseFeePerGas) :
-      parseInt(web3.utils.toWei('1', 'gwei'));
-    const getFees = (_blocks) => _blocks.filter(tx => !!tx.maxFeePerGas
-      ).map(tx => parseInt(tx.maxFeePerGas));    
-    return _estimateFee(this.blockBaseFeeCache, rpcEstimate, getFees);
+  async estimateBaseFee() {
+    const latestBlock = await this.web3.eth.getBlock('latest');
+    const rpcEstimate = latestBlock.baseFeePerGas ? latestBlock.baseFeePerGas : this.web3.utils.toWei('1', 'gwei');
+    const parsedRpcEstimate = parseInt(rpcEstimate);
+    const getFees = (_blocks) => _blocks
+      .filter(tx => !!tx.maxFeePerGas)
+      .map(tx => parseInt(tx.maxFeePerGas));    
+    return this._estimateFee(this.blockBaseFeeCache, parsedRpcEstimate, getFees);
   }
 
-  async estimatePriorityFee({ nBlocks }) {
+  async estimatePriorityFee() {
     // default to 1 gwei
-    const rpcEstimate = parseInt(web3.utils.toWei('1', 'gwei'));
-    const getFees = (_blocks) => _blocks.filter(tx => !!tx.maxPriorityFeePerGas
-      ).map(tx => parseInt(tx.maxPriorityFeePerGas));
-    return _estimateFee(this.blockPriorityFeeCache, rpcEstimate, getFees);
+    const rpcEstimate = parseInt(this.web3.utils.toWei('1', 'gwei'));
+    const getFees = (_blocks) => _blocks
+      .filter(tx => !!tx.maxPriorityFeePerGas)
+      .map(tx => parseInt(tx.maxPriorityFeePerGas));
+    return this._estimateFee(this.blockPriorityFeeCache, rpcEstimate, getFees);
   }
 
   async _getBestBlocks(cache, n = 10) {
@@ -235,7 +236,8 @@ class EthRPC {
   _getPercentile25Fees(blocks, cache, getFees) {
     let percentile25fees = [];
     for (const block of blocks) {
-      if (!block || (!block.percentile25 && (!block.transactions || !block.transactions.length)) ) {
+      const txs = block.transactions;
+      if (!block || (!block.percentile25 && (!txs || !txs.length)) ) {
         continue;
       }
 
@@ -243,11 +245,9 @@ class EthRPC {
       if (block.percentile25) {
         percentile25 = block.percentile25;
       } else {
-        const fees = getFees ? 
-          getFees(block.transactions) : 
-          block.transactions.map(parseInt(tx.gasPrice));
+        const fees = getFees ? getFees(txs) : txs.map((tx) => parseInt(tx.gasPrice));
         const feesSorted = fees.sort((a, b) => b - a);
-        percentile25 = feesSorted[Math.floor(block.transactions.length / 4)];  
+        percentile25 = feesSorted[Math.floor(txs.length / 4)];  
       }
       if (cache && block.number) {
         cache.set(block.number, { percentile25 });

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -299,6 +299,9 @@ class EthRPC {
         }
         if (cache) {
           cache.set(targetBlockNumber, block);
+          if (cache.size > n) {
+            cache.delete(Array.from(cache.keys()).sort()[0]);
+          }
         }
         return block;
       })

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -13,12 +13,9 @@ class EthRPC {
     this.web3 = this.getWeb3(this.config);
     this.account = this.config.account;
     this.emitter = new EventEmitter();
-    this.blockFeeCache = new Map();
-    // for the above single fee map would need to create
-    // a fee object with fields for gasPrice, baseFee, and priorityFee
     this.blockGasPriceCache = new Map();
-    this.blockBaseFeeCache = new Map();
-    this.blockPriorityFeeCache = new Map();
+    this.blockMaxBaseFeeCache = new Map();
+    this.blockMaxPriorityFeeCache = new Map();
   }
 
   getWeb3(web3Config) {
@@ -186,38 +183,54 @@ class EthRPC {
     return this.estimateGasPrice(nBlocks);
   }
 
-  async _estimateFee(cache, rpcEstimate, getFeesFn){
+  async _estimateFee(params) {
+    const { cache, rpcEstimate, percentile = 25, getFees } = params;
     const blocks = await this._getBestBlocks(cache);
-    const percentile25Fees = this._getPercentile25Fees(blocks, cache, getFeesFn);
-    if (!percentile25Fees.length) {
+    const percentileFees = this._getPercentileFees({ percentile, blocks, cache, getFees });
+    if (!percentileFees.length) {
       return rpcEstimate;
     }
-    const estimate = this._calculateFeeEstimate(percentile25Fees);
+    const estimate = this._calculateFeeEstimate(percentileFees);
     return Math.max(estimate, rpcEstimate);
   }
 
   async estimateGasPrice() {
     const rpcEstimate = parseInt(await this.web3.eth.getGasPrice());
-    return this._estimateFee(this.blockGasPriceCache, rpcEstimate);
+    return this._estimateFee({
+      cache: this.blockGasPriceCache,
+      rpcEstimate,
+      percentile: 25
+    });
   }
 
-  async estimateBaseFee() {
-    const latestBlock = await this.web3.eth.getBlock('latest');
-    const rpcEstimate = latestBlock.baseFeePerGas ? latestBlock.baseFeePerGas : this.web3.utils.toWei('1', 'gwei');
+  async estimateMaxBaseFee() {
+    const lastBlock = await this.web3.eth.getBlock('latest');
+    const rpcEstimate = lastBlock
+      .baseFeePerGas ? lastBlock.baseFeePerGas : this.web3.utils.toWei('1', 'gwei');
     const parsedRpcEstimate = parseInt(rpcEstimate);
     const getFees = (_blocks) => _blocks
       .filter(tx => !!tx.maxFeePerGas)
-      .map(tx => parseInt(tx.maxFeePerGas));    
-    return this._estimateFee(this.blockBaseFeeCache, parsedRpcEstimate, getFees);
+      .map(tx => parseInt(tx.maxFeePerGas));
+    return this._estimateFee({
+      cache: this.blockMaxBaseFeeCache,
+      rpcEstimate: parsedRpcEstimate,
+      percentile: 25,
+      getFees
+    });
   }
 
-  async estimatePriorityFee() {
+  async estimateMaxPriorityFee() {
     // default to 1 gwei
     const rpcEstimate = parseInt(this.web3.utils.toWei('1', 'gwei'));
     const getFees = (_blocks) => _blocks
       .filter(tx => !!tx.maxPriorityFeePerGas)
       .map(tx => parseInt(tx.maxPriorityFeePerGas));
-    return this._estimateFee(this.blockPriorityFeeCache, rpcEstimate, getFees);
+    return this._estimateFee({
+      cache: this.blockMaxPriorityFeeCache,
+      rpcEstimate,
+      percentile: 25,
+      getFees
+    });
   }
 
   async _getBestBlocks(cache, n = 10) {
@@ -233,36 +246,47 @@ class EthRPC {
     return blocks;
   }
 
-  _getPercentile25Fees(blocks, cache, getFees) {
-    let percentile25fees = [];
+  _getPercentileFees(params) {
+    const { percentile = 25, blocks, cache, getFees } = params;
+    let fees = [];
+    const percentileKey = 'percentile' + percentile;
     for (const block of blocks) {
       const txs = block.transactions;
-      if (!block || (!block.percentile25 && (!txs || !txs.length)) ) {
+      if (!block || (!block[percentileKey] && (!txs || !txs.length)) ) {
         continue;
       }
 
-      let percentile25;
-      if (block.percentile25) {
-        percentile25 = block.percentile25;
+      let percentileValue;
+      if (block[percentileKey]) {
+        percentileValue = block[percentileKey];
       } else {
         const fees = getFees ? getFees(txs) : txs.map((tx) => parseInt(tx.gasPrice));
         const feesSorted = fees.sort((a, b) => b - a);
-        percentile25 = feesSorted[Math.floor(txs.length / 4)];  
+        percentileValue = feesSorted[Math.floor(txs.length * percentile * 0.01)];  
       }
       if (cache && block.number) {
-        cache.set(block.number, { percentile25 });
+        let blockFees = {};
+        if (cache.has(block.number)) {
+          blockFees = cache.get(block.number);
+        }
+        blockFees[percentileKey] = percentileValue;
+        cache.set(block.number, blockFees);
         if (cache.size > 9) {
           cache.delete(Array.from(cache.keys()).sort()[0]);
         }
       }
-      percentile25fees.push(percentile25);
+      fees.push(percentileValue);
     }
-    return percentile25fees;
+    return fees;
   }
 
-  _calculateFeeEstimate(percentile25) {
-    const shortAverage = Math.ceil(percentile25.slice(0, percentile25.length / 2).reduce((acc, cur) => acc + cur, 0) / (percentile25.length / 2));
-    const longAverage = Math.ceil(percentile25.reduce((acc, cur) => acc + cur, 0) / percentile25.length);
+  _calculateFeeEstimate(fees) {
+    const shortAverage = Math.ceil(fees
+      .slice(0, fees.length / 2)
+      .reduce((acc, cur) => acc + cur, 0) / (fees.length / 2)
+    );
+    const longAverage = Math.ceil(fees
+      .reduce((acc, cur) => acc + cur, 0) / fees.length);
     const divergence = Math.abs(shortAverage - longAverage);
     return Math.max(shortAverage, longAverage) + divergence;
   }

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -13,7 +13,12 @@ class EthRPC {
     this.web3 = this.getWeb3(this.config);
     this.account = this.config.account;
     this.emitter = new EventEmitter();
+    this.blockFeeCache = new Map();
+    // for the above single fee map would need to create
+    // a fee object with fields for gasPrice, baseFee, and priorityFee
     this.blockGasPriceCache = new Map();
+    this.blockBaseFeeCache = new Map();
+    this.blockPriorityFeeCache = new Map();
   }
 
   getWeb3(web3Config) {
@@ -181,17 +186,52 @@ class EthRPC {
     return this.estimateGasPrice(nBlocks);
   }
 
+  _estimateFee(cache, rpcEstimate, getFeesFn){
+    const blocks = this._getBestBlocks(cache);
+    const percentile25GasPrices = this._getPercentile25(blocks, this.blockGasPriceCache, getFeesFn);
+    if (!percentile25GasPrices.length) {
+      return rpcEstimate;
+    }
+    const estimate = this._calculateFeeEstimate(percentile25GasPrices);
+    return Math.max(estimate, rpcEstimate);
+  }
+
   async estimateGasPrice() {
+    const rpcEstimate = parseInt(await this.web3.eth.getGasPrice());
+    return _estimateFee(this.blockGasPriceCache, rpcEstimate);
+  }
+
+  async estimateBaseFee({ nBlocks }) {
+    const latestBlock = await web3.eth.getBlock('latest');
+    const rpcEstimate = latestBlock.baseFeePerGas ? parseInt(latestBlock.baseFeePerGas) : 0;
+    const getFees = (_blocks) => _blocks.filter(tx => !!tx.maxFeePerGas
+      ).map(tx => parseInt(tx.maxFeePerGas));    
+    return _estimateFee(this.blockBaseFeeCache, rpcEstimate, getFees);
+  }
+
+  async estimatePriorityFee({ nBlocks }) {
+    // default to 1 gwei
+    const rpcEstimate = parseInt(web3.utils.toWei('1', 'gwei'));
+    const getFees = (_blocks) => _blocks.filter(tx => !!tx.maxPriorityFeePerGas
+      ).map(tx => parseInt(tx.maxPriorityFeePerGas));
+    return _estimateFee(this.blockPriorityFeeCache, rpcEstimate, getFees);
+  }
+
+  async _getBestBlocks(cache, n = 10) {
     const bestBlock = await this.web3.eth.getBlockNumber();
-    const blocks = await Promise.all([...Array(10).keys()]
+    const blocks = await Promise.all([...Array(n).keys()]
       .map((n) => {
         let targetBlockNumber = bestBlock - n;
-        if (this.blockGasPriceCache.has(targetBlockNumber)) {
-          return this.blockGasPriceCache.get(targetBlockNumber);
+        if (cache && cache.has(targetBlockNumber)) {
+          return cache.get(targetBlockNumber);
         }
         return this.web3.eth.getBlock(targetBlockNumber, 1);
       }));
-    let percentile25GasPrices = [];
+    return blocks;
+  }
+
+  _getPercentile25(blocks, cache, getFees) {
+    let percentile25 = [];
     for (const block of blocks) {
       if (!block || (!block.percentile25 && (!block.transactions || !block.transactions.length)) ) {
         continue;
@@ -201,32 +241,32 @@ class EthRPC {
       if (block.percentile25) {
         percentile25 = block.percentile25;
       } else {
-        const gasPrices = block.transactions.map(tx => parseInt(tx.gasPrice)).sort((a, b) => b - a);
-        percentile25 = gasPrices[Math.floor(block.transactions.length / 4)];
+        const gasValues = getFees ? 
+          getFees(block.transactions) : 
+          block.transactions.map(parseInt(tx.gasPrice));
+        const gasValuesSorted = gasValues.sort((a, b) => b - a);
+        percentile25 = gasValuesSorted[Math.floor(block.transactions.length / 4)];  
       }
-
-      if (block.number) {
-        this.blockGasPriceCache.set(block.number, { percentile25 });
-        if (this.blockGasPriceCache.size > 9) {
-          this.blockGasPriceCache.delete(Array.from(this.blockGasPriceCache.keys()).sort()[0]);
+      if (cache && block.number) {
+        cache.set(block.number, { percentile25 });
+        if (cache.size > 9) {
+          cache.delete(Array.from(cache.keys()).sort()[0]);
         }
       }
-      percentile25GasPrices.push(percentile25);
+      percentile25.push(percentile25);
     }
-    const rpcEstimate = parseInt(await this.web3.eth.getGasPrice());
-    if (!percentile25GasPrices.length) {
-      return rpcEstimate;
-    }
-    const shortAverage = Math.ceil(percentile25GasPrices.slice(0, percentile25GasPrices.length / 2).reduce((acc, cur) => acc + cur, 0) / (percentile25GasPrices.length / 2));
-    const longAverage = Math.ceil(percentile25GasPrices.reduce((acc, cur) => acc + cur, 0) / percentile25GasPrices.length);
+    return percentile25;
+  }
+
+  _calculateFeeEstimate(percentile25) {
+    const shortAverage = Math.ceil(percentile25.slice(0, percentile25.length / 2).reduce((acc, cur) => acc + cur, 0) / (percentile25.length / 2));
+    const longAverage = Math.ceil(percentile25.reduce((acc, cur) => acc + cur, 0) / percentile25.length);
     const divergence = Math.abs(shortAverage - longAverage);
-    const estimate = Math.max(shortAverage, longAverage) + divergence;
-    return Math.max(estimate, rpcEstimate);
+    return Math.max(shortAverage, longAverage) + divergence;
   }
 
   async getBestBlockHash() {
-    const bestBlock = await this.web3.eth.getBlockNumber();
-    const block = await this.web3.eth.getBlock(bestBlock);
+    const block = await this.web3.eth.getBlock('latest');
     const blockHash = block.hash;
     return blockHash;
   }

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -241,8 +241,8 @@ class EthRPC {
    * @param {number} [params.priority] - Optional: The maxPriorityFee to be used with the baseFee.
    * @returns {number} The estimated maximum base fee.
    */
-  async estimateMaxFee({ percentile,  priority }) {
-    const lastBlock = await this.web3.eth.getBlock('latest');    
+  async estimateMaxFee({ percentile, priority }) {
+    const lastBlock = await this.web3.eth.getBlock('latest');
     const baseFeePerGas = parseInt(lastBlock.baseFeePerGas) ? parseInt(lastBlock.baseFeePerGas) : 0;
     const gwei = parseInt(this.web3.utils.toWei('1', 'gwei'));
 
@@ -255,8 +255,8 @@ class EthRPC {
       const maxPriorityFee = await this.estimateMaxPriorityFee({ percentile });
       return 2 * baseFeePerGas + maxPriorityFee;
     }
-    // default max fee formmula. ensures inclusion in next block
-    return 2 * baseFeePerGas + (2.5 * gwei); 
+    // default max fee formula. ensures inclusion in next block
+    return 2 * baseFeePerGas + (2.5 * gwei);
   }
 
   /**
@@ -286,8 +286,8 @@ class EthRPC {
    */
   async _getRecentBlocks({ n = 10 }) {
     const bestBlock = await this.web3.eth.getBlockNumber();
-    let cache = this.blockCache;
-    let blocks = await Promise.all(
+    const cache = this.blockCache;
+    const blocks = await Promise.all(
       [...Array(n).keys()].map(async (n) => {
         const targetBlockNumber = bestBlock - n;
         if (cache && cache.has(targetBlockNumber)) {
@@ -338,7 +338,7 @@ class EthRPC {
         const feesSorted = _fees.sort((a, b) => b - a);
         percentileValue = feesSorted[Math.floor(feesSorted.length * (percentile / 100))];
       }
-      if(!Number.isInteger(percentileValue)) { 
+      if (!Number.isInteger(percentileValue)) { 
         continue;
       }
       // set quick fee retrieval cache

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -186,8 +186,8 @@ class EthRPC {
     return this.estimateGasPrice(nBlocks);
   }
 
-  _estimateFee(cache, rpcEstimate, getFeesFn){
-    const blocks = this._getBestBlocks(cache);
+  async _estimateFee(cache, rpcEstimate, getFeesFn){
+    const blocks = await this._getBestBlocks(cache);
     const percentile25Fees = this._getPercentile25Fees(blocks, cache, getFeesFn);
     if (!percentile25Fees.length) {
       return rpcEstimate;

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -14,7 +14,6 @@ class EthRPC {
     this.account = this.config.account;
     this.emitter = new EventEmitter();
     this.blockGasPriceCache = new Map();
-    this.blockMaxFeeCache = new Map();
     this.blockMaxPriorityFeeCache = new Map();
   }
 
@@ -183,16 +182,19 @@ class EthRPC {
    * Estimates the fee for a transaction.
    * @param {Object} params - The parameters for estimating the fee.
    * @param {number} params.nBlocks - The number of blocks to consider for the estimation.
-   * @param {string} [params.txType='0'] - The type of transaction fee estimation. '2' for EIP-1559 style, '0' for legacy.
-   * @returns {Promise<Object|number>} The estimated fee. If txType is '2', returns an object with maxFee and priorityFee. Otherwise, returns a number.
+   * @param {string} [params.txType='0'] - The type of transaction fee estimation. '2' or 'eip-1559' style, '0' or 'legacy'.
+   * @param {number} [params.percentile] - Optional: For type 2 txs, The priority fee percentile from last block to use for the estimation.
+   * @param {number} [params.priority] - Optional: For type 2 txs, The priority fFee to be used with the baseFee.
+   * @returns {Promise<number>} The estimated fee. If txType is '2', returns the sum of maxFee and priorityFee. Otherwise, returns a number.
    */
-  async estimateFee({ nBlocks, txType = '0' }) {
-    switch (txType) {
+  async estimateFee({ nBlocks, txType = '0', priority, percentile }) {
+    const _txType = txType.toString().toLowerCase();
+    switch (_txType) {
+      case 'eip-1559':
       case '2':
-        return { 
-          maxFee: await this.estimateMaxFee({}), 
-          priorityFee: await this.estimatePriorityFee({}) 
-        };
+        return await this.estimateMaxFee({ percentile, priority }); // default to 2* base + prioity (2.5 gwei) if priority level is set we determine the percentile vale 
+      case 'legacy':
+      case '0':
       default:
         return await this.estimateGasPrice(nBlocks);
     }
@@ -231,25 +233,27 @@ class EthRPC {
   }
 
   /**
-   * Estimates the maximum base fee.
+   * Estimates the maximum base fee. Defaults to 2 * baseFee + 2.5 gwei.
    * @param {Object} params - The parameters for estimating the maximum base fee.
-   * @param {number} [params.percentile=25] - The percentile to use for the estimation.
-   * @returns {Promise<number>} The estimated maximum base fee.
+   * @param {number} [params.percentile] - Optional: The maxPriorityFee percentile from last block to use for the estimation.
+   * @param {number} [params.priority] - Optional: The maxPriorityFee to be used with the baseFee.
+   * @returns {number} The estimated maximum base fee.
    */
-  async estimateMaxFee({ percentile = 25 }) {
-    const lastBlock = await this.web3.eth.getBlock('latest');
-    // a blocks base fee is the lowest acceptied MaxFee from the last block. 
-    const rpcEstimate = lastBlock.baseFeePerGas ? lastBlock.baseFeePerGas : this.web3.utils.toWei('1', 'gwei');
-    const parsedRpcEstimate = parseInt(rpcEstimate);
-    const getFees = (_txs) => _txs
-      .filter((tx) => !!tx.maxFeePerGas)
-      .map((tx) => parseInt(tx.maxFeePerGas));
-    return this._estimateFee({
-      cache: this.blockMaxFeeCache,
-      rpcEstimate: parsedRpcEstimate,
-      percentile,
-      getFees,
-    });
+  async estimateMaxFee({ percentile,  priority }) {
+    const lastBlock = await this.web3.eth.getBlock('latest');    
+    const baseFeePerGas = parseInt(lastBlock.baseFeePerGas) ? parseInt(lastBlock.baseFeePerGas) : 0;
+
+    if (priority && parseInt(priority) > 0) {
+      // user defined priority fee
+      return baseFeePerGas + priority;
+    }
+    if (percentile && parseInt(percentile) > 0 && parseInt(percentile) <= 100) {
+      // percentile bases priority fee
+      const maxPriorityFee = await this.estimateMaxPriorityFee({percentile});
+      return baseFeePerGas + maxPriorityFee;
+    }
+    // default max fee formmula. ensures inclusion in next block
+    return 2 * baseFeePerGas + parseInt(this.web3.utils.toWei('2.5', 'gwei'));
   }
 
   /**
@@ -259,7 +263,7 @@ class EthRPC {
    * @returns {Promise<number>} The estimated maximum priority fee.
    */
   async estimateMaxPriorityFee({ percentile = 25 }) {
-    const rpcEstimate = parseInt(this.web3.utils.toWei('1', 'gwei'));
+    const rpcEstimate = parseInt(this.web3.utils.toWei('2.5', 'gwei'));
     const getFees = (_txs) => _txs
       .filter((tx) => !!tx.maxPriorityFeePerGas)
       .map((tx) => parseInt(tx.maxPriorityFeePerGas));
@@ -305,8 +309,7 @@ class EthRPC {
     const percentileKey = `percentile${percentile}`;
     let fees = [];
     for (const block of blocks) {
-      const txs = block.transactions;
-      if (!block || (!block[percentileKey] && (!txs || !txs.length))) {
+      if (!block || (!block[percentileKey] && (!block.transactions || !block.transactions.length))) {
         continue;
       }
 
@@ -315,7 +318,7 @@ class EthRPC {
       if (block[percentileKey]) {
         percentileValue = block[percentileKey];
       } else {
-        const _fees = getFees ? getFees(txs) : txs.map((tx) => parseInt(tx.gasPrice));
+        const _fees = getFees ? getFees(block.transactions) : block.transactions.map((tx) => parseInt(tx.gasPrice));
         const feesSorted = _fees.sort((a, b) => b - a);
         percentileValue = feesSorted[Math.floor(feesSorted.length * (percentile / 100))];
       }
@@ -328,7 +331,9 @@ class EthRPC {
           cache.delete(Array.from(cache.keys()).sort()[0]);
         }
       }
-      fees.push(percentileValue);
+      if(Number.isInteger(percentileValue)) {
+        fees.push(percentileValue);
+      }
     }
     return fees;
   }

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -188,11 +188,11 @@ class EthRPC {
 
   _estimateFee(cache, rpcEstimate, getFeesFn){
     const blocks = this._getBestBlocks(cache);
-    const percentile25GasPrices = this._getPercentile25(blocks, this.blockGasPriceCache, getFeesFn);
-    if (!percentile25GasPrices.length) {
+    const percentile25Fees = this._getPercentile25Fees(blocks, cache, getFeesFn);
+    if (!percentile25Fees.length) {
       return rpcEstimate;
     }
-    const estimate = this._calculateFeeEstimate(percentile25GasPrices);
+    const estimate = this._calculateFeeEstimate(percentile25Fees);
     return Math.max(estimate, rpcEstimate);
   }
 
@@ -203,7 +203,9 @@ class EthRPC {
 
   async estimateBaseFee({ nBlocks }) {
     const latestBlock = await web3.eth.getBlock('latest');
-    const rpcEstimate = latestBlock.baseFeePerGas ? parseInt(latestBlock.baseFeePerGas) : 0;
+    const rpcEstimate = latestBlock.baseFeePerGas ?
+      parseInt(latestBlock.baseFeePerGas) :
+      parseInt(web3.utils.toWei('1', 'gwei'));
     const getFees = (_blocks) => _blocks.filter(tx => !!tx.maxFeePerGas
       ).map(tx => parseInt(tx.maxFeePerGas));    
     return _estimateFee(this.blockBaseFeeCache, rpcEstimate, getFees);
@@ -230,8 +232,8 @@ class EthRPC {
     return blocks;
   }
 
-  _getPercentile25(blocks, cache, getFees) {
-    let percentile25 = [];
+  _getPercentile25Fees(blocks, cache, getFees) {
+    let percentile25fees = [];
     for (const block of blocks) {
       if (!block || (!block.percentile25 && (!block.transactions || !block.transactions.length)) ) {
         continue;
@@ -241,11 +243,11 @@ class EthRPC {
       if (block.percentile25) {
         percentile25 = block.percentile25;
       } else {
-        const gasValues = getFees ? 
+        const fees = getFees ? 
           getFees(block.transactions) : 
           block.transactions.map(parseInt(tx.gasPrice));
-        const gasValuesSorted = gasValues.sort((a, b) => b - a);
-        percentile25 = gasValuesSorted[Math.floor(block.transactions.length / 4)];  
+        const feesSorted = fees.sort((a, b) => b - a);
+        percentile25 = feesSorted[Math.floor(block.transactions.length / 4)];  
       }
       if (cache && block.number) {
         cache.set(block.number, { percentile25 });
@@ -253,9 +255,9 @@ class EthRPC {
           cache.delete(Array.from(cache.keys()).sort()[0]);
         }
       }
-      percentile25.push(percentile25);
+      percentile25fees.push(percentile25);
     }
-    return percentile25;
+    return percentile25fees;
   }
 
   _calculateFeeEstimate(percentile25) {

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -302,7 +302,7 @@ class EthRPC {
       } else {
         const _fees = getFees ? getFees(txs) : txs.map((tx) => parseInt(tx.gasPrice));
         const feesSorted = _fees.sort((a, b) => b - a);
-        percentileValue = feesSorted[Math.floor(feesSorted.length * percentile * 0.01)];
+        percentileValue = feesSorted[Math.floor(feesSorted.length * (percentile / 100))];
       }
       // set quick fee retrieval cache
       if (cache && block.number) {

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -14,7 +14,7 @@ class EthRPC {
     this.account = this.config.account;
     this.emitter = new EventEmitter();
     this.blockGasPriceCache = new Map();
-    this.blockMaxBaseFeeCache = new Map();
+    this.blockMaxFeeCache = new Map();
     this.blockMaxPriorityFeeCache = new Map();
   }
 
@@ -183,9 +183,17 @@ class EthRPC {
     return this.estimateGasPrice(nBlocks);
   }
 
-  async _estimateFee(params) {
-    const { cache, rpcEstimate, percentile = 25, getFees } = params;
-    const blocks = await this._getBestBlocks(cache);
+  /**
+   * Estimates the fee.
+   * @param {Object} params - The parameters for estimating the fee.
+   * @param {Map} params.cache - The cache of block fees.
+   * @param {number} params.rpcEstimate - The RPC estimate of the fee.
+   * @param {number} [params.percentile=25] - The percentile to use for the estimation.
+   * @param {Function} params.getFees - The function to get the fees from the blocks.
+   * @returns {Promise<number>} The estimated fee.
+   */
+  async _estimateFee({ cache, rpcEstimate, percentile = 25, getFees }) {
+    const blocks = await this._getRecentBlocks({ cache });
     const percentileFees = this._getPercentileFees({ percentile, blocks, cache, getFees });
     if (!percentileFees.length) {
       return rpcEstimate;
@@ -194,81 +202,111 @@ class EthRPC {
     return Math.max(estimate, rpcEstimate);
   }
 
+  /**
+   * Estimates the gas price.
+   * @returns {Promise<number>} The estimated gas price.
+   */
   async estimateGasPrice() {
     const rpcEstimate = parseInt(await this.web3.eth.getGasPrice());
     return this._estimateFee({
       cache: this.blockGasPriceCache,
       rpcEstimate,
-      percentile: 25
-    });
-  }
-
-  async estimateMaxBaseFee() {
-    const lastBlock = await this.web3.eth.getBlock('latest');
-    const rpcEstimate = lastBlock
-      .baseFeePerGas ? lastBlock.baseFeePerGas : this.web3.utils.toWei('1', 'gwei');
-    const parsedRpcEstimate = parseInt(rpcEstimate);
-    const getFees = (_blocks) => _blocks
-      .filter(tx => !!tx.maxFeePerGas)
-      .map(tx => parseInt(tx.maxFeePerGas));
-    return this._estimateFee({
-      cache: this.blockMaxBaseFeeCache,
-      rpcEstimate: parsedRpcEstimate,
       percentile: 25,
-      getFees
     });
   }
 
-  async estimateMaxPriorityFee() {
-    // default to 1 gwei
+  /**
+   * Estimates the maximum base fee.
+   * @param {Object} params - The parameters for estimating the maximum base fee.
+   * @param {number} [params.percentile=25] - The percentile to use for the estimation.
+   * @returns {Promise<number>} The estimated maximum base fee.
+   */
+  async estimateMaxFee({ percentile = 25 }) {
+    const lastBlock = await this.web3.eth.getBlock('latest');
+    // a blocks base fee is the lowest acceptied MaxFee from the last block. 
+    const rpcEstimate = lastBlock.baseFeePerGas ? lastBlock.baseFeePerGas : this.web3.utils.toWei('1', 'gwei');
+    const parsedRpcEstimate = parseInt(rpcEstimate);
+    const getFees = (_txs) => _txs
+      .filter((tx) => !!tx.maxFeePerGas)
+      .map((tx) => parseInt(tx.maxFeePerGas));
+    return this._estimateFee({
+      cache: this.blockMaxFeeCache,
+      rpcEstimate: parsedRpcEstimate,
+      percentile,
+      getFees,
+    });
+  }
+
+  /**
+   * Estimates the maximum priority fee.
+   * @param {Object} params - The parameters for estimating the maximum priority fee.
+   * @param {number} [params.percentile=25] - The percentile to use for the estimation.
+   * @returns {Promise<number>} The estimated maximum priority fee.
+   */
+  async estimateMaxPriorityFee({ percentile = 25 }) {
     const rpcEstimate = parseInt(this.web3.utils.toWei('1', 'gwei'));
-    const getFees = (_blocks) => _blocks
-      .filter(tx => !!tx.maxPriorityFeePerGas)
-      .map(tx => parseInt(tx.maxPriorityFeePerGas));
+    const getFees = (_txs) => _txs
+      .filter((tx) => !!tx.maxPriorityFeePerGas)
+      .map((tx) => parseInt(tx.maxPriorityFeePerGas));
     return this._estimateFee({
       cache: this.blockMaxPriorityFeeCache,
       rpcEstimate,
-      percentile: 25,
-      getFees
+      percentile,
+      getFees,
     });
   }
 
-  async _getBestBlocks(cache, n = 10) {
+  /**
+   * Fetches the last n blocks from the blockchain.
+   * @param {Object} params - The parameters for fetching the blocks.
+   * @param {Map} params.cache - The cache to use for storing the blocks.
+   * @param {number} [params.n=10] - The number of blocks to fetch.
+   * @returns {Promise<Array>} The fetched blocks.
+   */
+  async _getRecentBlocks({ cache, n = 10 }) {
     const bestBlock = await this.web3.eth.getBlockNumber();
-    const blocks = await Promise.all([...Array(n).keys()]
-      .map((n) => {
-        let targetBlockNumber = bestBlock - n;
+    const blocks = await Promise.all(
+      [...Array(n).keys()].map((n) => {
+        const targetBlockNumber = bestBlock - n;
         if (cache && cache.has(targetBlockNumber)) {
           return cache.get(targetBlockNumber);
         }
         return this.web3.eth.getBlock(targetBlockNumber, 1);
-      }));
+      })
+    );
     return blocks;
   }
 
-  _getPercentileFees(params) {
-    const { percentile = 25, blocks, cache, getFees } = params;
+  /**
+   * Gets the percentile fees for the given blocks.
+   * @param {Object} params - The parameters for getting the percentile fees.
+   * @param {number} [params.percentile=25] - The percentile to get the fees for.
+   * @param {Array} params.blocks - The blocks to get the fees from.
+   * @param {Map} params.cache - The cache to use for storing the fees.
+   * @param {Function} params.getFees - The function to use for getting the fees from the transactions.
+   * @returns {Array} The percentile fees for the given blocks.
+   */
+  _getPercentileFees({ percentile = 25, blocks, cache, getFees }) {
+    const percentileKey = `percentile${percentile}`;
     let fees = [];
-    const percentileKey = 'percentile' + percentile;
     for (const block of blocks) {
       const txs = block.transactions;
-      if (!block || (!block[percentileKey] && (!txs || !txs.length)) ) {
+      if (!block || (!block[percentileKey] && (!txs || !txs.length))) {
         continue;
       }
 
       let percentileValue;
+      // get percentile fee
       if (block[percentileKey]) {
         percentileValue = block[percentileKey];
       } else {
-        const fees = getFees ? getFees(txs) : txs.map((tx) => parseInt(tx.gasPrice));
-        const feesSorted = fees.sort((a, b) => b - a);
-        percentileValue = feesSorted[Math.floor(txs.length * percentile * 0.01)];  
+        const _fees = getFees ? getFees(txs) : txs.map((tx) => parseInt(tx.gasPrice));
+        const feesSorted = _fees.sort((a, b) => b - a);
+        percentileValue = feesSorted[Math.floor(feesSorted.length * percentile * 0.01)];
       }
+      // set quick fee retrieval cache
       if (cache && block.number) {
-        let blockFees = {};
-        if (cache.has(block.number)) {
-          blockFees = cache.get(block.number);
-        }
+        let blockFees = cache.has(block.number) ? cache.get(block.number) : {};
         blockFees[percentileKey] = percentileValue;
         cache.set(block.number, blockFees);
         if (cache.size > 9) {
@@ -280,6 +318,11 @@ class EthRPC {
     return fees;
   }
 
+  /**
+   * Calculates the fee estimate.
+   * @param {Array} fees - The fees to calculate the estimate from.
+   * @returns {number} The calculated fee estimate.
+   */
   _calculateFeeEstimate(fees) {
     const shortAverage = Math.ceil(fees
       .slice(0, fees.length / 2)

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -294,13 +294,13 @@ class EthRPC {
           return cache.get(targetBlockNumber);
         }
         const block = await this.web3.eth.getBlock(targetBlockNumber, 1);
-        if(!block) {
+        if (!block) {
           throw new Error(`Unable to fetch block ${targetBlockNumber}`);
         }
         if (cache) {
           cache.set(targetBlockNumber, block);
           if (cache.size > n) {
-            cache.delete(Array.from(cache.keys()).sort()[0]);
+            cache.delete(Array.from(cache.keys()).sort((a, b) => a - b)[0]);
           }
         }
         return block;
@@ -347,7 +347,7 @@ class EthRPC {
         blockFees[percentileKey] = percentileValue;
         cache.set(block.number, blockFees);
         if (cache.size > 9) {
-          cache.delete(Array.from(cache.keys()).sort()[0]);
+          cache.delete(Array.from(cache.keys()).sort((a, b) => a - b)[0]);
         }
       }
       fees.push(percentileValue);

--- a/lib/eth/EthRpc.js
+++ b/lib/eth/EthRpc.js
@@ -179,8 +179,23 @@ class EthRPC {
     return resultArray;
   }
 
-  estimateFee({ nBlocks }) {
-    return this.estimateGasPrice(nBlocks);
+  /**
+   * Estimates the fee for a transaction.
+   * @param {Object} params - The parameters for estimating the fee.
+   * @param {number} params.nBlocks - The number of blocks to consider for the estimation.
+   * @param {string} [params.txType='0'] - The type of transaction fee estimation. '2' for EIP-1559 style, '0' for legacy.
+   * @returns {Promise<Object|number>} The estimated fee. If txType is '2', returns an object with maxFee and priorityFee. Otherwise, returns a number.
+   */
+  async estimateFee({ nBlocks, txType = '0' }) {
+    switch (txType) {
+      case '2':
+        return { 
+          maxFee: await this.estimateMaxFee({}), 
+          priorityFee: await this.estimatePriorityFee({}) 
+        };
+      default:
+        return await this.estimateGasPrice(nBlocks);
+    }
   }
 
   /**

--- a/tests/eth.js
+++ b/tests/eth.js
@@ -60,6 +60,31 @@ describe('ETH Tests', function() {
     expect(ethRPC.web3.eth.getBlock.callCount).to.be.lt(10);
   });
 
+  it('should estimate fee for type 2 transaction', async () => {
+    sinon.spy(ethRPC.web3.eth, 'getBlock');
+    let maxFee = await ethRPC.estimateFee({txType: 2, priority: 5});
+    assert.isDefined(maxFee);
+    expect(maxFee).to.be.equal(5154455240);
+    expect(ethRPC.web3.eth.getBlock.callCount).to.equal(1);
+  });
+
+  it('should estimate max fee', async () => {
+    sinon.spy(ethRPC.web3.eth, 'getBlock');
+    let maxFee = await ethRPC.estimateMaxFee({});
+    assert.isDefined(maxFee);
+    expect(maxFee).to.be.equal(2654455240);
+    expect(ethRPC.web3.eth.getBlock.callCount).to.equal(1);
+  });
+
+  it('should estimate max priority fee', async () => {
+    sinon.spy(ethRPC.blockMaxPriorityFeeCache, 'set');
+    const maxPriorityFee = await ethRPC.estimateMaxPriorityFee({});
+    assert.isDefined(maxPriorityFee);
+    expect(maxPriorityFee).to.be.gt(0);
+    expect(maxPriorityFee).to.be.equal(2500000000);
+    expect(ethRPC.blockMaxPriorityFeeCache.set.callCount).to.equal(0);
+  });
+
   it('should estimate fee', async () => {
     const fee = await rpcs.estimateFee({ currency, nBlocks: 4 });
     assert.isTrue(fee === 20000000000);

--- a/tests/eth.js
+++ b/tests/eth.js
@@ -76,6 +76,16 @@ describe('ETH Tests', function() {
     expect(ethRPC.web3.eth.getBlock.callCount).to.equal(1);
   });
 
+  it('should estimate max fee using priority fee percentile', async () => {
+    sinon.spy(ethRPC.emitter, 'emit');
+    sinon.spy(ethRPC.web3.eth, 'getBlock');
+    let maxFee = await ethRPC.estimateMaxFee({ percentile: 15 });
+    assert.isDefined(maxFee); 
+    expect(maxFee).to.be.equal(2654455240);
+    expect(ethRPC.web3.eth.getBlock.callCount).to.be.lt(10);
+    expect(ethRPC.emitter.emit.callCount).to.equal(0);
+  });
+
   it('should estimate max priority fee', async () => {
     sinon.spy(ethRPC.blockMaxPriorityFeeCache, 'set');
     const maxPriorityFee = await ethRPC.estimateMaxPriorityFee({});

--- a/tests/xrp.js
+++ b/tests/xrp.js
@@ -62,8 +62,11 @@ describe('XRP Tests', function() {
 
     expect(block).to.have.property('ledger');
     let ledger = block.ledger;
-    expect(ledger).to.have.property('accepted');
-    expect(ledger.accepted).to.equal(true);
+    // from xrpl documentation: https://xrpl.org/ledger.html (9/26/2023)
+    // The following fields are deprecated and may be removed without further notice: accepted, totalCoins (use total_coins instead).
+    // as a result the following is commented out
+    // expect(ledger).to.have.property('accepted');
+    // expect(ledger.accepted).to.equal(true);
     expect(ledger).to.have.property('ledger_hash');
     expect(ledger).to.have.property('ledger_index');
     expect(ledger).to.have.property('parent_hash');


### PR DESCRIPTION
Enable the ability to estimate fees for EVM type 2 transactions.

- returns a type 2 tx fee estimate as an object returning both the maxBaseFee and priorityFee based on EIP-1559
- breaks out the estimateFee function into smaller functions
- enables the ability to set a percentile fee level (i.e 25% = slow tx speed, 75% = fast tx speed) for maxBaseFee and priorityFee