### PR TITLE
add hash to signed transactions

### DIFF
--- a/lib/xrp/XrpRpc.js
+++ b/lib/xrp/XrpRpc.js
@@ -161,6 +161,11 @@ class XrpRpc {
 
   async decodeRawTransaction({ rawTx }) {
     const txJSON = xrpl.decode(rawTx);
+
+    if (txJSON.TxnSignature) {
+      txJSON.hash = xrpl.hashes.hashSignedTx(rawTx);
+    }
+
     return txJSON;
   }
 


### PR DESCRIPTION
Computes hash for signed transaction to use for transaction look, e.g. rippled tx <hash>