### PR TITLE
Add Solana Parsed Transaciton Data

### DIFF
--- a/lib/sol/SolRpc.js
+++ b/lib/sol/SolRpc.js
@@ -5,7 +5,7 @@ const SolToken = require('@solana-program/token');
 const { pipe } = require('@solana/functional');
 const EventEmitter = require('events');
 const bs58 = require('bs58');
-const TransactionParser = require('./transaction-parser');
+const { parseInstructions } = require('./transaction-parser');
 const SOL_ERROR_MESSAGES = require('./error_messages');
 
 class SolRPC {
@@ -451,13 +451,18 @@ class SolRPC {
     if (!serializedTransactionObject?.transaction) {
       return null;
     }
-    const { blockTime, transaction, slot } = serializedTransactionObject;
+    const { blockTime, transaction, slot, meta } = serializedTransactionObject;
     // transaciton is an array with [rawTx, 'base64']
     const serializedTransaction = transaction[0];
     const base64Encoder = SolKit.getBase64Encoder();
     const transactionBytes = base64Encoder.encode(serializedTransaction);
     const parsedTransaction = await this.decodeRawTransaction({ rawTx: transactionBytes });
-    return { ...parsedTransaction, blockTime: Number(blockTime), slot: Number(slot) };
+    return {
+      ...parsedTransaction, 
+      blockTime: Number(blockTime),
+      slot: Number(slot),
+      meta
+    };
   }
 
   /**
@@ -594,7 +599,7 @@ class SolRPC {
       lifetimeConstraint.nonce = decompiledTransactionMessage.lifetimeConstraint.nonce;
     }
 
-    const instructions = TransactionParser.parseInstructions(decompiledTransactionMessage.instructions);
+    const instructions = parseInstructions(decompiledTransactionMessage.instructions);
 
     let status, confirmations;
     try {

--- a/lib/sol/SolRpc.js
+++ b/lib/sol/SolRpc.js
@@ -616,7 +616,8 @@ class SolRPC {
       status,
       confirmations,
       version: compiledTransactionMessage.version,
-      instructions
+      instructions,
+      feePayerAddress
     };
 
     if (lifetimeConstraint.blockhash || lifetimeConstraint.nonce) {

--- a/lib/sol/transaction-parser.js
+++ b/lib/sol/transaction-parser.js
@@ -4,6 +4,17 @@ const SolSystem = require('@solana-program/system');
 const SolToken = require('@solana-program/token');
 const solTokenProgramAddress = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
 
+
+const instructionKeys = {
+  TRANSFER_SOL: 'transferSol',
+  TRANSFER_CHECKED_TOKEN: 'transferCheckedToken',
+  ADVANCE_NONCE_ACCOUNT: 'advanceNonceAccount',
+  MEMO: 'memo',
+  SET_COMPUTE_UNIT_LIMIT: 'setComputeUnitLimit',
+  SET_COMPUTE_UNIT_PRICE: 'setComputeUnitPrice',
+  UNKNOWN: 'unknownInstruction',
+};
+
 /**
  * @param {any[]} instructions 
  * @returns {Instructions}
@@ -24,7 +35,7 @@ const parseInstructions = (instructions) => {
       handledInstruction = parseComputeBudgetProgramInstruction(instruction);
     } else {
       handledInstruction = {
-        key: 'unknownInstruction',
+        key: instructionKeys.UNKNOWN,
         value: instruction
       };
     }
@@ -46,12 +57,12 @@ const parseSystemProgramInstruction = (instruction) => {
     const currency = 'SOL';
     const destination = accounts.destination.address;
     const source = accounts.source.address;
-    parsedInstruction.key = 'transferSol';
+    parsedInstruction.key = instructionKeys.TRANSFER_SOL;
     parsedInstruction.value = { amount, currency, destination, source };
   } else if (identifiedInstruction === SolSystem.SystemInstruction.AdvanceNonceAccount) {
     const parsedAdvanceNonceAccountInstruction = SolSystem.parseAdvanceNonceAccountInstruction(instruction);
     const { nonceAccount, nonceAuthority } = parsedAdvanceNonceAccountInstruction.accounts;
-    parsedInstruction.key = 'advanceNonceAccount',
+    parsedInstruction.key = instructionKeys.ADVANCE_NONCE_ACCOUNT,
     parsedInstruction.value = {
       nonceAccount: nonceAccount.address,
       nonceAuthority: nonceAuthority.address
@@ -66,7 +77,7 @@ const parseSystemProgramInstruction = (instruction) => {
 const parseMemoProgramInstruction = (instruction) => {
   const parsedInstruction = {};
   const parsedMemoInstruction = SolMemo.parseAddMemoInstruction({...instruction}); // Only one instruction with MEMO_PROGRAM_ADDRESS
-  parsedInstruction.key = 'memo';
+  parsedInstruction.key = instructionKeys.MEMO;
   parsedInstruction.value = parsedMemoInstruction.data;
   return parsedInstruction;
 };
@@ -85,7 +96,7 @@ const parseTokenProgramInstruction = (instruction) => {
   if (identifiedTokenInstruction === SolToken.TokenInstruction.Transfer) {
     const parsedTransferTokenInstruction = SolToken.parseTransferInstruction(instruction);
     const { accounts, data } = parsedTransferTokenInstruction;
-    parsedInstruction.key = 'transferToken';
+    parsedInstruction.key = instructionKeys.TRANSFER_SOL;
     parsedInstruction.value = {
       authority: accounts.authority.address,
       destination: accounts.destination.address,
@@ -95,7 +106,7 @@ const parseTokenProgramInstruction = (instruction) => {
   } else if (identifiedTokenInstruction === SolToken.TokenInstruction.TransferChecked) {
     const parsedTransferCheckedTokenInstruction = SolToken.parseTransferCheckedInstruction(instruction);
     const { accounts, data } = parsedTransferCheckedTokenInstruction;
-    parsedInstruction.key = 'transferCheckedToken';
+    parsedInstruction.key = instructionKeys.TRANSFER_CHECKED_TOKEN;
     parsedInstruction.value = {
       authority: accounts.authority.address,
       destination: accounts.destination.address,
@@ -116,13 +127,13 @@ const parseComputeBudgetProgramInstruction = (instruction) => {
   const identifiedComputeBudgetInstruction = SolComputeBudget.identifyComputeBudgetInstruction(instruction);
   if (identifiedComputeBudgetInstruction === SolComputeBudget.ComputeBudgetInstruction.SetComputeUnitLimit) {
     const parsedSetComputeUnitLimitInstruction = SolComputeBudget.parseSetComputeUnitLimitInstruction(instruction);
-    parsedInstruction.key = 'setComputeUnitLimit';
+    parsedInstruction.key = instructionKeys.SET_COMPUTE_UNIT_LIMIT;
     parsedInstruction.value = {
       computeUnitLimit: parsedSetComputeUnitLimitInstruction.data.units
     };
   } else if (identifiedComputeBudgetInstruction === SolComputeBudget.ComputeBudgetInstruction.SetComputeUnitPrice) {
     const parsedSetComputeUnitPriceInstruction = SolComputeBudget.parseSetComputeUnitPriceInstruction(instruction);
-    parsedInstruction.key = 'setComputeUnitPrice';
+    parsedInstruction.key = instructionKeys.SET_COMPUTE_UNIT_PRICE;
     parsedInstruction.value = {
       priority: true,
       microLamports: Number(parsedSetComputeUnitPriceInstruction.data.microLamports)
@@ -135,7 +146,8 @@ const parseComputeBudgetProgramInstruction = (instruction) => {
 };
 
 module.exports = {
-  parseInstructions
+  parseInstructions,
+  instructionKeys
 };
 
 /**


### PR DESCRIPTION
Adds meta and feePayerAddress fields to the parsed transaction object
Creates and exports instruction key types